### PR TITLE
make global rules compatible with dashboard

### DIFF
--- a/pkg/apisix/global_rule.go
+++ b/pkg/apisix/global_rule.go
@@ -17,6 +17,7 @@ package apisix
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"go.uber.org/zap"
 
@@ -112,6 +113,17 @@ func (r *globalRuleClient) List(ctx context.Context) ([]*v1.GlobalRule, error) {
 func (r *globalRuleClient) Create(ctx context.Context, obj *v1.GlobalRule, shouldCompare bool) (*v1.GlobalRule, error) {
 	if v, skip := skipRequest(r.cluster, shouldCompare, r.url, obj.ID, obj); skip {
 		return v, nil
+	}
+
+	//Overwrite global rule ID with the plugin name
+	if len(obj.Plugins) == 0 { //This case will not happen as its handled at schema validation level
+		return nil, fmt.Errorf("global rule must have at least one plugin")
+	}
+
+	//This is checked on dashboard that global rule id should be the plugin name
+	for pluginName := range obj.Plugins {
+		obj.ID = pluginName
+		break
 	}
 
 	log.Debugw("try to create global_rule",

--- a/samples/deploy/crd/v1/ApisixGlobalRule.yaml
+++ b/samples/deploy/crd/v1/ApisixGlobalRule.yaml
@@ -51,6 +51,8 @@ spec:
                 ingressClassName:
                   type: string
                 plugins:
+                  minItems: 1
+                  maxItems: 1
                   type: array
                   items:
                     type: object


### PR DESCRIPTION
- This PR makes sure that only one plugin can be passed per global rule.
- The global rule ID sent to dashboard will be satisfy the constraint that its one of the plugin names