### PR TITLE
fix: update ADC to use JSON instead of YAML

### DIFF
--- a/internal/provider/adc/adc.go
+++ b/internal/provider/adc/adc.go
@@ -8,6 +8,11 @@ import (
 	"os"
 	"os/exec"
 
+	"go.uber.org/zap"
+	networkingv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	types "github.com/api7/api7-ingress-controller/api/adc"
 	"github.com/api7/api7-ingress-controller/api/v1alpha1"
 	"github.com/api7/api7-ingress-controller/internal/controller/config"
@@ -15,10 +20,6 @@ import (
 	"github.com/api7/api7-ingress-controller/internal/provider"
 	"github.com/api7/api7-ingress-controller/internal/provider/adc/translator"
 	"github.com/api7/gopkg/pkg/log"
-	"go.uber.org/zap"
-	networkingv1 "k8s.io/api/networking/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type adcClient struct {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When generating ids for resources in adc.yaml, there is a chance that an id like `8e287857` will be generated, which adc will recognize as a number and cause an error. We can use a json file instead of a yaml file.

```yaml
services:
  - hosts:
      - httpbin.example
    id: 8e287857
...
```

adc lint log

```log
The following errors were found in configuration:
#1 Expected string, received number at service: "ingress-apisix-e2e-tests-default-894183279_httpbin-0006_0", field: "id"
```

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/api7-ingress-controller#community) first**
