### PR TITLE
feat: Update HTTPRoutePolicy handling for Ingress

### DIFF
--- a/internal/controller/httproutepolicy.go
+++ b/internal/controller/httproutepolicy.go
@@ -122,7 +122,8 @@ func (r *IngressReconciler) processHTTPRoutePolicies(tctx *provider.TranslateCon
 		list v1alpha1.HTTPRoutePolicyList
 		key  = indexer.GenHTTPRoutePolicyIndexKey(networkingv1.GroupName, "Ingress", ingress.GetNamespace(), ingress.GetName(), "")
 	)
-	if err := r.List(ctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
+	if err := r.List(context.Background(), &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
+		return err
 	}
 
 	for _, item := range list.Items {

--- a/internal/controller/httproutepolicy.go
+++ b/internal/controller/httproutepolicy.go
@@ -122,8 +122,7 @@ func (r *IngressReconciler) processHTTPRoutePolicies(tctx *provider.TranslateCon
 		list v1alpha1.HTTPRoutePolicyList
 		key  = indexer.GenHTTPRoutePolicyIndexKey(networkingv1.GroupName, "Ingress", ingress.GetNamespace(), ingress.GetName(), "")
 	)
-	if err := r.List(context.Background(), &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		return err
+	if err := r.List(ctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
 	}
 
 	for _, item := range list.Items {

--- a/internal/controller/indexer/indexer.go
+++ b/internal/controller/indexer/indexer.go
@@ -23,6 +23,7 @@ const (
 	IngressClassRef    = "ingressClassRef"
 	ConsumerGatewayRef = "consumerGatewayRef"
 	PolicyTargetRefs   = "targetRefs"
+	PolicyTargetRefIng = "targetRefIng"
 )
 
 func SetupIndexer(mgr ctrl.Manager) error {
@@ -189,6 +190,16 @@ func setupIngressIndexer(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// create HTTPRoutePolicy index
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&v1alpha1.HTTPRoutePolicy{},
+		PolicyTargetRefIng,
+		IngressHTTPRouteIndexFunc,
+	); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -254,6 +265,10 @@ func IngressSecretIndexFunc(rawObj client.Object) []string {
 		secrets = append(secrets, key)
 	}
 	return secrets
+}
+
+func IngressHTTPRouteIndexFunc(rawObj client.Object) []string {
+	return []string{GenHTTPRoutePolicyIndexKey(networkingv1.GroupName, "Ingress", rawObj.GetGenerateName(), rawObj.GetName(), "")}
 }
 
 func GenIndexKeyWithGK(group, kind, namespace, name string) string {

--- a/internal/controller/indexer/indexer.go
+++ b/internal/controller/indexer/indexer.go
@@ -23,7 +23,6 @@ const (
 	IngressClassRef    = "ingressClassRef"
 	ConsumerGatewayRef = "consumerGatewayRef"
 	PolicyTargetRefs   = "targetRefs"
-	PolicyTargetRefIng = "targetRefIng"
 )
 
 func SetupIndexer(mgr ctrl.Manager) error {
@@ -186,16 +185,6 @@ func setupIngressIndexer(mgr ctrl.Manager) error {
 		&networkingv1.IngressClass{},
 		IngressClass,
 		IngressClassIndexFunc,
-	); err != nil {
-		return err
-	}
-
-	// create HTTPRoutePolicy index
-	if err := mgr.GetFieldIndexer().IndexField(
-		context.Background(),
-		&v1alpha1.HTTPRoutePolicy{},
-		PolicyTargetRefIng,
-		IngressHTTPRouteIndexFunc,
 	); err != nil {
 		return err
 	}

--- a/internal/controller/indexer/indexer.go
+++ b/internal/controller/indexer/indexer.go
@@ -268,7 +268,7 @@ func IngressSecretIndexFunc(rawObj client.Object) []string {
 }
 
 func IngressHTTPRouteIndexFunc(rawObj client.Object) []string {
-	return []string{GenHTTPRoutePolicyIndexKey(networkingv1.GroupName, "Ingress", rawObj.GetGenerateName(), rawObj.GetName(), "")}
+	return []string{GenHTTPRoutePolicyIndexKey(networkingv1.GroupName, "Ingress", rawObj.GetNamespace(), rawObj.GetName(), "")}
 }
 
 func GenIndexKeyWithGK(group, kind, namespace, name string) string {

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -409,25 +409,12 @@ func (r *IngressReconciler) listIngressesByHTTPRoutePolicy(ctx context.Context, 
 }
 
 func (r *IngressReconciler) listIngressesForGenericEvent(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
-	var namespacedNameMap = make(map[types.NamespacedName]struct{})
-
-	switch v := obj.(type) {
+	switch obj.(type) {
 	case *v1alpha1.HTTPRoutePolicy:
-		for _, ref := range v.Spec.TargetRefs {
-			namespacedName := types.NamespacedName{Namespace: v.GetNamespace(), Name: string(ref.Name)}
-			if _, ok := namespacedNameMap[namespacedName]; !ok {
-				namespacedNameMap[namespacedName] = struct{}{}
-				if err := r.Get(ctx, namespacedName, new(networkingv1.Ingress)); err != nil {
-					r.Log.Error(err, "failed to Get Ingress", "namespace", namespacedName.Namespace, "name", namespacedName.Name)
-					continue
-				}
-				requests = append(requests, reconcile.Request{NamespacedName: namespacedName})
-			}
-		}
+		return r.listIngressesByHTTPRoutePolicy(ctx, obj)
 	default:
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to HTTPRoutePolicy")
 	}
-
 	return
 }
 

--- a/internal/provider/adc/translator/ingress.go
+++ b/internal/provider/adc/translator/ingress.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"strings"
 
-	adctypes "github.com/api7/api7-ingress-controller/api/adc"
-	"github.com/api7/api7-ingress-controller/internal/controller/label"
-	"github.com/api7/api7-ingress-controller/internal/id"
-	"github.com/api7/api7-ingress-controller/internal/provider"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	adctypes "github.com/api7/api7-ingress-controller/api/adc"
+	"github.com/api7/api7-ingress-controller/internal/controller/label"
+	"github.com/api7/api7-ingress-controller/internal/id"
+	"github.com/api7/api7-ingress-controller/internal/provider"
 )
 
 func (t *Translator) translateIngressTLS(ingressTLS *networkingv1.IngressTLS, secret *corev1.Secret, labels map[string]string) (*adctypes.SSL, error) {
@@ -183,8 +184,8 @@ func (t *Translator) TranslateIngress(tctx *provider.TranslateContext, obj *netw
 				}
 			}
 			route.Uris = uris
-
 			service.Routes = []*adctypes.Route{route}
+			t.fillHTTPRoutePoliciesForIngress(tctx, service.Routes)
 			result.Services = append(result.Services, service)
 		}
 	}

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -724,7 +724,7 @@ spec:
 			s.Logf(message)
 		})
 
-		It("HTTPRoutePolicy conflicts", func() {
+		FIt("HTTPRoutePolicy conflicts", func() {
 			const httpRoutePolicy0 = `
 apiVersion: gateway.apisix.io/v1alpha1
 kind: HTTPRoutePolicy
@@ -785,11 +785,11 @@ spec:
 				Expect(err).NotTo(HaveOccurred(), "creating HTTPRoutePolicy")
 			}
 			for _, name := range []string{"http-route-policy-0", "http-route-policy-1", "http-route-policy-2"} {
-				Eventually(func() string {
+				Eventually(func(name string) string {
 					spec, err := s.GetResourceYaml("HTTPRoutePolicy", name)
 					Expect(err).NotTo(HaveOccurred(), "getting HTTPRoutePolicy yaml")
 					return spec
-				}).WithTimeout(8 * time.Second).ProbeEvery(time.Second).
+				}).WithArguments(name).WithTimeout(10 * time.Second).ProbeEvery(time.Second).
 					Should(ContainSubstring("reason: Conflicted"))
 			}
 

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -724,7 +724,7 @@ spec:
 			s.Logf(message)
 		})
 
-		FIt("HTTPRoutePolicy conflicts", func() {
+		It("HTTPRoutePolicy conflicts", func() {
 			const httpRoutePolicy0 = `
 apiVersion: gateway.apisix.io/v1alpha1
 kind: HTTPRoutePolicy


### PR DESCRIPTION
Refactor the HTTPRoutePolicy update function to handle Ingress objects and improve logging. Add functionality to process HTTPRoutePolicies for Ingress in the IngressReconciler. Update tests to include scenarios for HTTPRoutePolicy targeting Ingress.

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/api7-ingress-controller#community) first**
