### PR TITLE
chore: Update group names to apisix.apache.org

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -13,7 +13,7 @@ resources:
     namespaced: true
   controller: true
   domain: github.com
-  group: gateway.apisix.io
+  group: apisix.apache.org
   kind: Guestbook
   path: github.com/api7/api7-ingress-controller/api/v1alpha1
   version: v1alpha1
@@ -22,7 +22,7 @@ resources:
     namespaced: true
   controller: true
   domain: github.com
-  group: gateway.apisix.io
+  group: apisix.apache.org
   kind: GatewayProxy
   path: github.com/api7/api7-ingress-controller/api/v1alpha1
   version: v1alpha1
@@ -30,7 +30,7 @@ resources:
     crdVersion: v1
     namespaced: true
   domain: github.com
-  group: gateway.apisix.io
+  group: apisix.apache.org
   kind: HTTPRoutePolicy
   path: github.com/api7/api7-ingress-controller/api/v1alpha1
   version: v1alpha1

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the gateway.apisix.io v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the apisix.apache.org v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=gateway.apisix.io
+// +groupName=apisix.apache.org
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "gateway.apisix.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "apisix.apache.org", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/charts/crds/gateway.apisix.io_plugingconfig.yaml
+++ b/charts/crds/gateway.apisix.io_plugingconfig.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: pluginconfigs.gateway.apisix.io
+  name: pluginconfigs.apisix.apache.org
 spec:
-  group: gateway.apisix.io
+  group: apisix.apache.org
   names:
     kind: PluginConfig
     listKind: PluginConfigList

--- a/charts/templates/cluster_role.yaml
+++ b/charts/templates/cluster_role.yaml
@@ -102,7 +102,7 @@ rules:
   - get
   - update
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - pluginconfigs
   - pluginsconfigs/status

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -7,6 +7,6 @@ data:
   config.yaml: |
     log_level: "{{ .Values.logLevel | default "debug" }}"
 
-    controller_name: {{ .Values.controllerName | default "gateway.api7.io/api7-ingress-controller" }}
+    controller_name: {{ .Values.controllerName | default "apisix.apache.org/api7-ingress-controller" }}
 
     leader_election_id: "api7-ingress-controller-leader"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -2,7 +2,7 @@ nameOverride: ""
 labelsOverride: {}
 annotations: {}
 podAnnotations: {}
-controllerName: gateway.apisix.io/api7-ingress-controller
+controllerName: apisix.apache.org/api7-ingress-controller
 replicas: 1
 admin:
   key: '' # Pass the admin key generated for the ingress gateway group

--- a/config/crd/bases/gateway.apisix.io_backendtrafficpolicies.yaml
+++ b/config/crd/bases/gateway.apisix.io_backendtrafficpolicies.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: backendtrafficpolicies.gateway.apisix.io
+  name: backendtrafficpolicies.apisix.apache.org
 spec:
-  group: gateway.apisix.io
+  group: apisix.apache.org
   names:
     kind: BackendTrafficPolicy
     listKind: BackendTrafficPolicyList

--- a/config/crd/bases/gateway.apisix.io_consumers.yaml
+++ b/config/crd/bases/gateway.apisix.io_consumers.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: consumers.gateway.apisix.io
+  name: consumers.apisix.apache.org
 spec:
-  group: gateway.apisix.io
+  group: apisix.apache.org
   names:
     kind: Consumer
     listKind: ConsumerList

--- a/config/crd/bases/gateway.apisix.io_gatewayproxies.yaml
+++ b/config/crd/bases/gateway.apisix.io_gatewayproxies.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: gatewayproxies.gateway.apisix.io
+  name: gatewayproxies.apisix.apache.org
 spec:
-  group: gateway.apisix.io
+  group: apisix.apache.org
   names:
     kind: GatewayProxy
     listKind: GatewayProxyList

--- a/config/crd/bases/gateway.apisix.io_httproutepolicies.yaml
+++ b/config/crd/bases/gateway.apisix.io_httproutepolicies.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: httproutepolicies.gateway.apisix.io
+  name: httproutepolicies.apisix.apache.org
 spec:
-  group: gateway.apisix.io
+  group: apisix.apache.org
   names:
     kind: HTTPRoutePolicy
     listKind: HTTPRoutePolicyList

--- a/config/crd/bases/gateway.apisix.io_pluginconfigs.yaml
+++ b/config/crd/bases/gateway.apisix.io_pluginconfigs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: pluginconfigs.gateway.apisix.io
+  name: pluginconfigs.apisix.apache.org
 spec:
-  group: gateway.apisix.io
+  group: apisix.apache.org
   names:
     kind: PluginConfig
     listKind: PluginConfigList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,18 +2,18 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/gateway.apisix.io_pluginconfigs.yaml
-- bases/gateway.apisix.io_gatewayproxies.yaml
-- bases/gateway.apisix.io_consumers.yaml
-- bases/gateway.apisix.io_backendtrafficpolicies.yaml
-- bases/gateway.apisix.io_httproutepolicies.yaml
+- bases/apisix.apache.org_pluginconfigs.yaml
+- bases/apisix.apache.org_gatewayproxies.yaml
+- bases/apisix.apache.org_consumers.yaml
+- bases/apisix.apache.org_backendtrafficpolicies.yaml
+- bases/apisix.apache.org_httproutepolicies.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 - path: patches/consumer_credential_oneof.yaml
   target:
     kind: CustomResourceDefinition
-    name: consumers.gateway.apisix.io
+    name: consumers.apisix.apache.org
     group: apiextensions.k8s.io
     version: v1
 

--- a/config/rbac/gatewayproxy_editor_role.yaml
+++ b/config/rbac/gatewayproxy_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: gatewayproxy-editor-role
 rules:
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - gatewayproxies
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - gatewayproxies/status
   verbs:

--- a/config/rbac/gatewayproxy_viewer_role.yaml
+++ b/config/rbac/gatewayproxy_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: gatewayproxy-viewer-role
 rules:
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - gatewayproxies
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - gatewayproxies/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,6 +36,67 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apisix.apache.org
+  resources:
+  - backendtrafficpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apisix.apache.org
+  resources:
+  - backendtrafficpolicies/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apisix.apache.org
+  resources:
+  - consumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apisix.apache.org
+  resources:
+  - consumers/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apisix.apache.org
+  resources:
+  - gatewayproxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apisix.apache.org
+  resources:
+  - httproutepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apisix.apache.org
+  resources:
+  - httproutepolicies/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apisix.apache.org
+  resources:
+  - pluginconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -51,67 +112,6 @@ rules:
   - discovery.k8s.io
   resources:
   - endpointslices
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - backendtrafficpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - backendtrafficpolicies/status
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - consumers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - consumers/status
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - gatewayproxies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - httproutepolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - httproutepolicies/status
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - gateway.apisix.io
-  resources:
-  - pluginconfigs
   verbs:
   - get
   - list

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -1,9 +1,9 @@
 log_level: "info"                               # The log level of the API7 Ingress Controller.
                                                 # the default value is "info".
 
-controller_name: gateway.apisix.io/api7-ingress-controller  # The controller name of the API7 Ingress Controller,
+controller_name: apisix.apache.org/api7-ingress-controller  # The controller name of the API7 Ingress Controller,
                                                           # which is used to identify the controller in the GatewayClass.
-                                                          # The default value is "gateway.api7.io/api7-ingress-controller".
+                                                          # The default value is "apisix.apache.org/api7-ingress-controller".
 leader_election_id: "api7-ingress-controller-leader" # The leader election ID for the API7 Ingress Controller.
                                                         # The default value is "api7-ingress-controller-leader".
 leader_election:

--- a/config/samples/gateway.apisix.io_v1alpha1_consumer.yaml
+++ b/config/samples/gateway.apisix.io_v1alpha1_consumer.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
   name: consumer-sample

--- a/config/samples/gateway.apisix.io_v1alpha1_gatewayproxy.yaml
+++ b/config/samples/gateway.apisix.io_v1alpha1_gatewayproxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   labels:

--- a/config/samples/gateway.apisix.io_v1alpha1_httproutepolicy.yaml
+++ b/config/samples/gateway.apisix.io_v1alpha1_httproutepolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.apisix.io.github.com/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   labels:

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -8,9 +8,9 @@ The API7 Ingress Controller is a Kubernetes Ingress Controller that implements t
 log_level: "info"                               # The log level of the API7 Ingress Controller.
                                                 # the default value is "info".
 
-controller_name: gateway.apisix.io/api7-ingress-controller  # The controller name of the API7 Ingress Controller,
+controller_name: apisix.apache.org/api7-ingress-controller  # The controller name of the API7 Ingress Controller,
                                                           # which is used to identify the controller in the GatewayClass.
-                                                          # The default value is "gateway.api7.io/api7-ingress-controller".
+                                                          # The default value is "apisix.apache.org/api7-ingress-controller".
 
 leader_election_id: "api7-ingress-controller-leader" # The leader election ID for the API7 Ingress Controller.
                                                         # The default value is "api7-ingress-controller-leader".
@@ -26,7 +26,7 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.api7.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 ```
 
 ### Addresses

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -41,7 +41,7 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.api7.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 
 ---
 

--- a/examples/httpbin/httproute.yaml
+++ b/examples/httpbin/httproute.yaml
@@ -3,11 +3,11 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.apisix.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 
 ---
 
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -36,7 +36,7 @@ spec:
     port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 

--- a/examples/httpbin/ingress.yaml
+++ b/examples/httpbin/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -21,9 +21,9 @@ kind: IngressClass
 metadata:
   name: api7
 spec:
-  controller: "gateway.apisix.io/api7-ingress-controller"
+  controller: "apisix.apache.org/api7-ingress-controller"
   parameters:
-    apiGroup: "gateway.apisix.io"
+    apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "api7-proxy-config"
     namespace: "default"

--- a/examples/httpbin/quickstart.yaml
+++ b/examples/httpbin/quickstart.yaml
@@ -61,11 +61,11 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.apisix.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 
 ---
 
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -94,7 +94,7 @@ spec:
     port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 

--- a/examples/httpbin/service-rewrite-host.yaml
+++ b/examples/httpbin/service-rewrite-host.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: httpbin

--- a/examples/httpbin/service-timeout.yaml
+++ b/examples/httpbin/service-timeout.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: httpbin

--- a/internal/controller/config/types.go
+++ b/internal/controller/config/types.go
@@ -12,7 +12,7 @@ const (
 	// IngressClass is the default ingress class name, used for Ingress
 	// object's IngressClassName field in Kubernetes clusters version v1.18.0
 	// or higher, or the annotation "kubernetes.io/ingress.class" (deprecated).
-	DefaultControllerName = "gateway.api7.io/api7-ingress-controller"
+	DefaultControllerName = "apisix.apache.org/api7-ingress-controller"
 
 	// DefaultLogLevel is the default log level for apisix-ingress-controller.
 	DefaultLogLevel = "info"

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -20,14 +20,14 @@ import (
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 // CustomResourceDefinition
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=pluginconfigs,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=gatewayproxies,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=consumers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=consumers/status,verbs=get;update
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=backendtrafficpolicies,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=backendtrafficpolicies/status,verbs=get;update
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=httproutepolicies,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.apisix.io,resources=httproutepolicies/status,verbs=get;update
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=pluginconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=gatewayproxies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=consumers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=consumers/status,verbs=get;update
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=backendtrafficpolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=backendtrafficpolicies/status,verbs=get;update
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=httproutepolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apisix.apache.org,resources=httproutepolicies/status,verbs=get;update
 
 // GatewayAPI
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch;update

--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -7,18 +7,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/api7/api7-ingress-controller/test/e2e/framework"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/api7/api7-ingress-controller/test/e2e/framework"
 )
 
 var gatewayClassName = "api7"
-var controllerName = "gateway.api7.io/api7-ingress-controller"
+var controllerName = "apisix.apache.org/api7-ingress-controller"
 
 var gatewayClass = fmt.Sprintf(`
 apiVersion: gateway.networking.k8s.io/v1
@@ -30,7 +30,7 @@ spec:
 `, gatewayClassName, controllerName)
 
 var gatewayProxyYaml = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: conformance-gateway-proxy
@@ -142,7 +142,7 @@ func TestMain(m *testing.M) {
 	address := svc.Status.LoadBalancer.Ingress[0].IP
 
 	f.DeployIngress(framework.IngressDeployOpts{
-		ControllerName: "gateway.api7.io/api7-ingress-controller",
+		ControllerName: "apisix.apache.org/api7-ingress-controller",
 		AdminKey:       adminKey,
 		AdminTLSVerify: false,
 		Namespace:      namespace,
@@ -203,7 +203,7 @@ func patchGatewaysForConformanceTest(ctx context.Context, k8sClient client.Clien
 			// add infrastructure.parametersRef
 			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{
 				ParametersRef: &gatewayv1.LocalParametersReference{
-					Group: "gateway.apisix.io",
+					Group: "apisix.apache.org",
 					Kind:  "GatewayProxy",
 					Name:  "conformance-gateway-proxy",
 				},

--- a/test/e2e/crds/backendtrafficpolicy.go
+++ b/test/e2e/crds/backendtrafficpolicy.go
@@ -15,7 +15,7 @@ var _ = Describe("Test BackendTrafficPolicy base on HTTPRoute", func() {
 	s := scaffold.NewDefaultScaffold()
 
 	var defaultGatewayProxy = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -53,7 +53,7 @@ spec:
       port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
@@ -82,7 +82,7 @@ spec:
 `
 	Context("Rewrite Upstream Host", func() {
 		var createUpstreamHost = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: httpbin
@@ -96,7 +96,7 @@ spec:
 `
 
 		var updateUpstreamHost = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: httpbin
@@ -147,11 +147,11 @@ spec:
 
 var _ = Describe("Test BackendTrafficPolicy base on Ingress", func() {
 	s := scaffold.NewScaffold(&scaffold.Options{
-		ControllerName: "gateway.api7.io/api7-ingress-controller",
+		ControllerName: "apisix.apache.org/api7-ingress-controller",
 	})
 
 	var defaultGatewayProxy = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -175,9 +175,9 @@ metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
 spec:
-  controller: "gateway.api7.io/api7-ingress-controller"
+  controller: "apisix.apache.org/api7-ingress-controller"
   parameters:
-    apiGroup: "gateway.apisix.io"
+    apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "api7-proxy-config"
     namespace: "default"
@@ -220,7 +220,7 @@ spec:
 
 	Context("Rewrite Upstream Host", func() {
 		var createUpstreamHost = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: httpbin
@@ -234,7 +234,7 @@ spec:
 `
 
 		var updateUpstreamHost = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: httpbin

--- a/test/e2e/crds/consumer.go
+++ b/test/e2e/crds/consumer.go
@@ -13,7 +13,7 @@ var _ = Describe("Test Consumer", func() {
 	s := scaffold.NewDefaultScaffold()
 
 	var defaultGatewayProxy = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -51,13 +51,13 @@ spec:
       port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
 
 	var defaultHTTPRoute = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
   name: auth-plugin-config
@@ -88,7 +88,7 @@ spec:
     filters:
     - type: ExtensionRef
       extensionRef:
-        group: gateway.apisix.io
+        group: apisix.apache.org
         kind: PluginConfig
         name: auth-plugin-config
     backendRefs:
@@ -98,7 +98,7 @@ spec:
 
 	Context("Consumer plugins", func() {
 		var limitCountConsumer = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
   name: consumer-sample
@@ -120,7 +120,7 @@ spec:
 `
 
 		var unlimitConsumer = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
   name: consumer-sample2
@@ -177,7 +177,7 @@ spec:
 
 	Context("Credential", func() {
 		var defaultCredential = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
   name: consumer-sample
@@ -199,7 +199,7 @@ spec:
       config:
         key: sample-key2
 `
-		var updateCredential = `apiVersion: gateway.apisix.io/v1alpha1
+		var updateCredential = `apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
   name: consumer-sample
@@ -310,7 +310,7 @@ data:
   password: c2FtcGxlLXBhc3N3b3Jk
 `
 		var defaultConsumer = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: Consumer
 metadata:
   name: consumer-sample

--- a/test/e2e/framework/manifests/ingress.yaml
+++ b/test/e2e/framework/manifests/ingress.yaml
@@ -107,7 +107,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - backendtrafficpolicies
   verbs:
@@ -115,14 +115,14 @@ rules:
   - list
   - watch
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - backendtrafficpolicies/status
   verbs:
   - get
   - update
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - consumers
   verbs:
@@ -130,14 +130,14 @@ rules:
   - list
   - watch
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - consumers/status
   verbs:
   - get
   - update
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - gatewayproxies
   verbs:
@@ -145,7 +145,7 @@ rules:
   - list
   - watch
 - apiGroups:
-    - gateway.apisix.io
+    - apisix.apache.org
   resources:
     - httproutepolicies
   verbs:
@@ -153,14 +153,14 @@ rules:
     - list
     - watch
 - apiGroups:
-    - gateway.apisix.io
+    - apisix.apache.org
   resources:
     - httproutepolicies/status
   verbs:
     - get
     - update
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - httproutepolicies
   verbs:
@@ -168,14 +168,14 @@ rules:
   - list
   - watch
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - httproutepolicies/status
   verbs:
   - get
   - update
 - apiGroups:
-  - gateway.apisix.io
+  - apisix.apache.org
   resources:
   - pluginconfigs
   verbs:

--- a/test/e2e/gatewayapi/controller.go
+++ b/test/e2e/gatewayapi/controller.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Check if controller cache gets synced with correct resources", func() {
 
 	var gatewayProxyYaml = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -55,7 +55,7 @@ spec:
       port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
@@ -120,7 +120,7 @@ metadata:
 	Context("Create resource with first controller", func() {
 		s1 := scaffold.NewScaffold(&scaffold.Options{
 			Name:           "gateway1",
-			ControllerName: "gateway.api7.io/api7-ingress-controller-1",
+			ControllerName: "apisix.apache.org/api7-ingress-controller-1",
 		})
 		var route1 = `
 apiVersion: gateway.networking.k8s.io/v1
@@ -160,13 +160,13 @@ spec:
 			routes, err := s1.DefaultDataplaneResource().Route().List(s1.Context)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes).To(HaveLen(1))
-			assert.Equal(GinkgoT(), routes[0].Labels["k8s/controller-name"], "gateway.api7.io/api7-ingress-controller-1")
+			assert.Equal(GinkgoT(), routes[0].Labels["k8s/controller-name"], "apisix.apache.org/api7-ingress-controller-1")
 		})
 	})
 	Context("Create resource with second controller", func() {
 		s2 := scaffold.NewScaffold(&scaffold.Options{
 			Name:           "gateway2",
-			ControllerName: "gateway.api7.io/api7-ingress-controller-2",
+			ControllerName: "apisix.apache.org/api7-ingress-controller-2",
 		})
 		var route2 = `
 apiVersion: gateway.networking.k8s.io/v1
@@ -206,7 +206,7 @@ spec:
 			routes, err := s2.DefaultDataplaneResource().Route().List(s2.Context)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes).To(HaveLen(1))
-			assert.Equal(GinkgoT(), routes[0].Labels["k8s/controller-name"], "gateway.api7.io/api7-ingress-controller-2")
+			assert.Equal(GinkgoT(), routes[0].Labels["k8s/controller-name"], "apisix.apache.org/api7-ingress-controller-2")
 		})
 	})
 })

--- a/test/e2e/gatewayapi/gateway.go
+++ b/test/e2e/gatewayapi/gateway.go
@@ -27,11 +27,11 @@ func createSecret(s *scaffold.Scaffold, secretName string) {
 
 var _ = Describe("Test Gateway", func() {
 	s := scaffold.NewScaffold(&scaffold.Options{
-		ControllerName: "gateway.api7.io/api7-ingress-controller",
+		ControllerName: "apisix.apache.org/api7-ingress-controller",
 	})
 
 	var gatewayProxyYaml = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -54,7 +54,7 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.api7.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 `
 
 		var defautlGateway = `
@@ -70,7 +70,7 @@ spec:
       port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
@@ -88,7 +88,7 @@ spec:
       port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
@@ -152,7 +152,7 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.api7.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 `
 
 			var defaultGateway = fmt.Sprintf(`
@@ -174,7 +174,7 @@ spec:
           name: %s
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `, host, secretName)
@@ -211,7 +211,7 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.api7.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 `
 
 				var defaultGateway = fmt.Sprintf(`
@@ -247,7 +247,7 @@ spec:
         name: %s
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `, secretName, secretName)
@@ -265,7 +265,7 @@ spec:
 				assert.Nil(GinkgoT(), err, "list tls error")
 				assert.Len(GinkgoT(), tls, 1, "tls number not expect")
 				assert.Equal(GinkgoT(), Cert, tls[0].Cert, "tls cert not expect")
-				assert.Equal(GinkgoT(), tls[0].Labels["k8s/controller-name"], "gateway.api7.io/api7-ingress-controller")
+				assert.Equal(GinkgoT(), tls[0].Labels["k8s/controller-name"], "apisix.apache.org/api7-ingress-controller")
 			})
 		})
 	})

--- a/test/e2e/gatewayapi/gatewayclass.go
+++ b/test/e2e/gatewayapi/gatewayclass.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("Test GatewayClass", func() {
 	s := scaffold.NewScaffold(&scaffold.Options{
-		ControllerName: "gateway.api7.io/api7-ingress-controller",
+		ControllerName: "apisix.apache.org/api7-ingress-controller",
 	})
 
 	Context("Create GatewayClass", func() {
@@ -21,7 +21,7 @@ kind: GatewayClass
 metadata:
   name: api7
 spec:
-  controllerName: "gateway.api7.io/api7-ingress-controller"
+  controllerName: "apisix.apache.org/api7-ingress-controller"
 `
 
 		var noGatewayClass = `
@@ -30,7 +30,7 @@ kind: GatewayClass
 metadata:
   name: api7-not-accepeted
 spec:
-  controllerName: "gateway.api7.io/not-exist"
+  controllerName: "apisix.apache.org/not-exist"
 `
 		It("Create GatewayClass", func() {
 			By("create default GatewayClass")

--- a/test/e2e/gatewayapi/gatewayproxy.go
+++ b/test/e2e/gatewayapi/gatewayproxy.go
@@ -37,13 +37,13 @@ spec:
       port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
 
 	var gatewayProxyWithEnabledPlugin = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -66,7 +66,7 @@ spec:
 `
 
 	var gatewayProxyWithDisabledPlugin = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -89,7 +89,7 @@ spec:
 `
 	var (
 		gatewayProxyWithPluginMetadata0 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -117,7 +117,7 @@ spec:
     }
 `
 		gatewayProxyWithPluginMetadata1 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -310,7 +310,7 @@ spec:
 
 	var (
 		gatewayProxyWithInvalidProviderType = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -319,7 +319,7 @@ spec:
     type: "InvalidType"
 `
 		gatewayProxyWithMissingControlPlane = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -328,7 +328,7 @@ spec:
     type: "ControlPlane"
 `
 		gatewayProxyWithValidProvider = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -19,7 +19,7 @@ var _ = Describe("Test HTTPRoute", func() {
 	s := scaffold.NewDefaultScaffold()
 
 	var gatewayProxyYaml = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -57,7 +57,7 @@ spec:
       port: 80
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
@@ -80,7 +80,7 @@ spec:
           name: test-apisix-tls
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: api7-proxy-config
 `
@@ -219,7 +219,7 @@ spec:
 		var additionalGatewayClassName string
 
 		var additionalGatewayProxyYaml = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: additional-proxy-config
@@ -251,7 +251,7 @@ spec:
           from: All
   infrastructure:
     parametersRef:
-      group: gateway.apisix.io
+      group: apisix.apache.org
       kind: GatewayProxy
       name: additional-proxy-config
 `
@@ -483,7 +483,7 @@ spec:
       port: 80
 `
 		const httpRoutePolicy = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-0
@@ -665,7 +665,7 @@ spec:
 
 			By("update HTTPRoutePolicy")
 			const changedHTTPRoutePolicy = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-0
@@ -708,7 +708,7 @@ spec:
 			Eventually(func() string {
 				_, err := s.GetResourceYaml("HTTPRoutePolicy", "http-route-policy-0")
 				return err.Error()
-			}).WithTimeout(8 * time.Second).ProbeEvery(time.Second).Should(ContainSubstring(`httproutepolicies.gateway.apisix.io "http-route-policy-0" not found`))
+			}).WithTimeout(8 * time.Second).ProbeEvery(time.Second).Should(ContainSubstring(`httproutepolicies.apisix.apache.org "http-route-policy-0" not found`))
 			// access the route without additional vars should be OK
 			message := retry.DoWithRetry(s.GinkgoT, "", 10, time.Second, func() (string, error) {
 				statusCode := s.NewAPISIXClient().
@@ -726,7 +726,7 @@ spec:
 
 		It("HTTPRoutePolicy conflicts", func() {
 			const httpRoutePolicy0 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-0
@@ -742,7 +742,7 @@ spec:
     - http-route-policy-0
 `
 			const httpRoutePolicy1 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-1
@@ -758,7 +758,7 @@ spec:
     - http-route-policy-0
 `
 			const httpRoutePolicy2 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-2
@@ -1014,7 +1014,7 @@ spec:
 `
 
 		var echoPlugin = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
   name: example-plugin-config
@@ -1025,7 +1025,7 @@ spec:
       body: "Hello, World!!"
 `
 		var echoPluginUpdated = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: PluginConfig
 metadata:
   name: example-plugin-config
@@ -1053,7 +1053,7 @@ spec:
     filters:
     - type: ExtensionRef
       extensionRef:
-        group: gateway.apisix.io
+        group: apisix.apache.org
         kind: PluginConfig
         name: example-plugin-config
     backendRefs:

--- a/test/e2e/ingress/ingress.go
+++ b/test/e2e/ingress/ingress.go
@@ -28,11 +28,11 @@ func createSecret(s *scaffold.Scaffold, secretName string) {
 
 var _ = Describe("Test Ingress", func() {
 	s := scaffold.NewScaffold(&scaffold.Options{
-		ControllerName: "gateway.api7.io/api7-ingress-controller",
+		ControllerName: "apisix.apache.org/api7-ingress-controller",
 	})
 
 	var gatewayProxyYaml = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -69,9 +69,9 @@ kind: IngressClass
 metadata:
   name: api7
 spec:
-  controller: "gateway.api7.io/api7-ingress-controller"
+  controller: "apisix.apache.org/api7-ingress-controller"
   parameters:
-    apiGroup: "gateway.apisix.io"
+    apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "api7-proxy-config"
     namespace: "default"
@@ -130,9 +130,9 @@ metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
 spec:
-  controller: "gateway.api7.io/api7-ingress-controller"
+  controller: "apisix.apache.org/api7-ingress-controller"
   parameters:
-    apiGroup: "gateway.apisix.io"
+    apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "api7-proxy-config"
     namespace: "default"
@@ -188,7 +188,7 @@ spec:
 
 	Context("IngressClass with GatewayProxy", func() {
 		gatewayProxyYaml := `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -206,7 +206,7 @@ spec:
 `
 
 		gatewayProxyWithSecretYaml := `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config-with-secret
@@ -234,9 +234,9 @@ metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
 spec:
-  controller: "gateway.api7.io/api7-ingress-controller"
+  controller: "apisix.apache.org/api7-ingress-controller"
   parameters:
-    apiGroup: "gateway.apisix.io"
+    apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "api7-proxy-config"
     namespace: "default"
@@ -249,9 +249,9 @@ kind: IngressClass
 metadata:
   name: api7-with-proxy-secret
 spec:
-  controller: "gateway.api7.io/api7-ingress-controller"
+  controller: "apisix.apache.org/api7-ingress-controller"
   parameters:
-    apiGroup: "gateway.apisix.io"
+    apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "api7-proxy-config-with-secret"
     namespace: "default"
@@ -369,7 +369,7 @@ stringData:
 	Context("HTTPRoutePolicy for Ingress", func() {
 		getGatewayProxySpec := func() string {
 			return fmt.Sprintf(`
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: GatewayProxy
 metadata:
   name: api7-proxy-config
@@ -393,9 +393,9 @@ kind: IngressClass
 metadata:
   name: api7
 spec:
-  controller: "gateway.api7.io/api7-ingress-controller"
+  controller: "apisix.apache.org/api7-ingress-controller"
   parameters:
-    apiGroup: "gateway.apisix.io"
+    apiGroup: "apisix.apache.org"
     kind: "GatewayProxy"
     name: "api7-proxy-config"
     namespace: "default"
@@ -421,7 +421,7 @@ spec:
               number: 80
 `
 		const httpRoutePolicySpec0 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-0
@@ -437,7 +437,7 @@ spec:
     - http-route-policy-0
 `
 		const httpRoutePolicySpec1 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-0
@@ -453,7 +453,7 @@ spec:
     - http-route-policy-0
 `
 		const httpRoutePolicySpec2 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-0
@@ -469,7 +469,7 @@ spec:
     - http-route-policy-0
 `
 		const httpRoutePolicySpec3 = `
-apiVersion: gateway.apisix.io/v1alpha1
+apiVersion: apisix.apache.org/v1alpha1
 kind: HTTPRoutePolicy
 metadata:
   name: http-route-policy-1

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -47,7 +47,7 @@ const (
 	DashboardHost = "localhost"
 	DashboardPort = 7080
 
-	DefaultControllerName = "gateway.api7.io/api7-ingress-controller"
+	DefaultControllerName = "apisix.apache.org/api7-ingress-controller"
 )
 
 type Options struct {


### PR DESCRIPTION
Change the group names from `gateway.apisix.io` to `apisix.apache.org` across multiple files including CRDs, examples, and test configurations to align with the new API group.

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/api7-ingress-controller#community) first**
