### PR TITLE
fix: httproute matching

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -38,7 +38,7 @@ var skippedTestsForTraditionalRoutes = []string{
 	tests.HTTPRouteListenerHostnameMatching.ShortName,
 
 	// tests.HTTPRouteMatching.ShortName,
-	tests.HTTPRouteMatchingAcrossRoutes.ShortName,
+	// tests.HTTPRouteMatchingAcrossRoutes.ShortName,
 
 	tests.GatewayInvalidTLSConfiguration.ShortName,
 	tests.HTTPRouteInvalidBackendRefUnknownKind.ShortName,


### PR DESCRIPTION
```
{
    Request:   http.Request{Path: "/", Headers: map[string]string{"Version": "two"}},
    Backend:   "infra-backend-v2",
    Namespace: ns,
},
                
{
    // Not a path segment prefix so should not match /v2.
    Request:   http.Request{Path: "/v2example"},
    Backend:   "infra-backend-v1",
    Namespace: ns,
}
```

Handle the above two cases

ref: https://gateway-api.sigs.k8s.io/reference/spec/#httprouterule