### PR TITLE
chore: Add e2e tests for GatewayProxy referencing Secret

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,8 @@ linters:
     revive:
       rules:
         - name: comment-spacings
+    lll:
+      line-length: 160
   exclusions:
     generated: lax
     rules:

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -40,7 +40,15 @@ func (r *ConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				predicate.NewPredicateFuncs(r.checkGatewayRef),
 			),
 		).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.NewPredicateFuncs(func(obj client.Object) bool {
+					_, ok := obj.(*corev1.Secret)
+					return ok
+				}),
+			),
+		).
 		Watches(&gatewayv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(r.listConsumersForGateway),
 			builder.WithPredicates(

--- a/internal/controller/ingressclass_controller.go
+++ b/internal/controller/ingressclass_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/api7/gopkg/pkg/log"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -15,8 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/api7/gopkg/pkg/log"
 
 	"github.com/api7/api7-ingress-controller/api/v1alpha1"
 	"github.com/api7/api7-ingress-controller/internal/controller/indexer"

--- a/internal/controller/ingressclass_controller.go
+++ b/internal/controller/ingressclass_controller.go
@@ -40,7 +40,15 @@ func (r *IngressClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				predicate.NewPredicateFuncs(r.matchesController),
 			),
 		).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.NewPredicateFuncs(func(obj client.Object) bool {
+					_, ok := obj.(*corev1.Secret)
+					return ok
+				}),
+			),
+		).
 		Watches(
 			&v1alpha1.GatewayProxy{},
 			handler.EnqueueRequestsFromMapFunc(r.listIngressClassesForGatewayProxy),

--- a/test/e2e/gatewayapi/gateway.go
+++ b/test/e2e/gatewayapi/gateway.go
@@ -112,7 +112,8 @@ spec:
 			Expect(gcyaml).To(ContainSubstring("message: the gatewayclass has been accepted by the api7-ingress-controller"), "checking GatewayClass condition message")
 
 			By("create Gateway")
-			err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.CurrentNamespace())
+			err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.
+				Namespace())
 			Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 			time.Sleep(5 * time.Second)
 
@@ -123,7 +124,7 @@ spec:
 			Expect(gwyaml).To(ContainSubstring("message: the gateway has been accepted by the api7-ingress-controller"), "checking Gateway condition message")
 
 			By("create Gateway with not accepted GatewayClass")
-			err = s.CreateResourceFromStringWithNamespace(noClassGateway, s.CurrentNamespace())
+			err = s.CreateResourceFromStringWithNamespace(noClassGateway, s.Namespace())
 			Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 			time.Sleep(5 * time.Second)
 
@@ -184,7 +185,7 @@ spec:
 			time.Sleep(5 * time.Second)
 
 			By("create Gateway")
-			err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.CurrentNamespace())
+			err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.Namespace())
 			Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 			time.Sleep(10 * time.Second)
 
@@ -257,7 +258,7 @@ spec:
 				time.Sleep(5 * time.Second)
 
 				By("create Gateway")
-				err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.CurrentNamespace())
+				err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.Namespace())
 				Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 				time.Sleep(10 * time.Second)
 

--- a/test/e2e/gatewayapi/gatewayclass.go
+++ b/test/e2e/gatewayapi/gatewayclass.go
@@ -77,7 +77,7 @@ spec:
 			}).WithTimeout(8 * time.Second).ProbeEvery(time.Second).Should(ContainSubstring(`status: "True"`))
 
 			By("create a Gateway")
-			err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.CurrentNamespace())
+			err = s.CreateResourceFromStringWithNamespace(defaultGateway, s.Namespace())
 			Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 			time.Sleep(time.Second)
 

--- a/test/e2e/gatewayapi/gatewayproxy.go
+++ b/test/e2e/gatewayapi/gatewayproxy.go
@@ -207,7 +207,7 @@ spec:
 		time.Sleep(5 * time.Second)
 
 		By("Create Gateway with GatewayProxy")
-		err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(gatewayWithProxy, gatewayClassName), s.CurrentNamespace())
+		err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(gatewayWithProxy, gatewayClassName), s.Namespace())
 		Expect(err).NotTo(HaveOccurred(), "creating Gateway with GatewayProxy")
 		time.Sleep(5 * time.Second)
 

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -125,7 +125,7 @@ spec:
 		Expect(gcyaml).To(ContainSubstring("message: the gatewayclass has been accepted by the api7-ingress-controller"), "checking GatewayClass condition message")
 
 		By("create Gateway")
-		err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(defaultGateway, gatewayClassName), s.CurrentNamespace())
+		err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(defaultGateway, gatewayClassName), s.Namespace())
 		Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 		time.Sleep(5 * time.Second)
 
@@ -158,7 +158,7 @@ spec:
 		Expect(gcyaml).To(ContainSubstring("message: the gatewayclass has been accepted by the api7-ingress-controller"), "checking GatewayClass condition message")
 
 		By("create Gateway")
-		err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(defaultGatewayHTTPS, gatewayClassName), s.CurrentNamespace())
+		err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(defaultGatewayHTTPS, gatewayClassName), s.Namespace())
 		Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 		time.Sleep(5 * time.Second)
 

--- a/test/e2e/scaffold/k8s.go
+++ b/test/e2e/scaffold/k8s.go
@@ -129,10 +129,6 @@ func (s *Scaffold) DeleteResourceFromStringWithNamespace(yaml, namespace string)
 	return k8s.KubectlDeleteFromStringE(s.t, s.kubectlOptions, yaml)
 }
 
-func (s *Scaffold) CurrentNamespace() string {
-	return s.kubectlOptions.Namespace
-}
-
 func (s *Scaffold) NewAPISIX() (dashboard.Dashboard, error) {
 	return dashboard.NewClient()
 }
@@ -272,7 +268,7 @@ func (s *Scaffold) ApplyDefaultGatewayResource(
 	)
 
 	By("create Gateway")
-	err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(defaultGateway, gatewayClassName), s.CurrentNamespace())
+	err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(defaultGateway, gatewayClassName), s.Namespace())
 	Expect(err).NotTo(HaveOccurred(), "creating Gateway")
 	time.Sleep(5 * time.Second)
 

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -811,3 +811,7 @@ func (s *Scaffold) GetGatewayGroupHTTPSEndpoint(gatewayGroupID string) (string, 
 
 	return resources.HttpsTunnel.Endpoint(), nil
 }
+
+func (s *Scaffold) CurrentGatewayGroupID() string {
+	return s.gatewaygroupid
+}


### PR DESCRIPTION


<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [x] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Introduce comprehensive e2e tests verifying GatewayProxy's ability to reference Secrets, including scenarios for creating, updating, and validating Secrets with admin keys. Update predicate filters to watch for Secret changes and replace `CurrentNamespace()` with `Namespace()` across multiple test files for consistency. Adjust line length configuration in `.golangci.yml` to accommodate the new test cases.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/api7-ingress-controller#community) first**
