### PR TITLE
fix: HTTPRouteInvalidNonExistentBackendRef

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -254,6 +254,9 @@ func SetRouteConditionResolvedRefs(routeParentStatus *gatewayv1.RouteParentStatu
 	if !status && strings.Contains(message, string(gatewayv1.RouteReasonInvalidKind)) {
 		reason = string(gatewayv1.RouteReasonInvalidKind)
 	}
+	if !status && strings.Contains(message, "Service") && strings.Contains(message, "not found") {
+		reason = string(gatewayv1.RouteReasonBackendNotFound)
+	}
 
 	condition := metav1.Condition{
 		Type:               string(gatewayv1.RouteConditionResolvedRefs),

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -40,7 +40,6 @@ var skippedTestsForTraditionalRoutes = []string{
 	tests.GatewayInvalidTLSConfiguration.ShortName,
 	// tests.HTTPRouteInvalidBackendRefUnknownKind.ShortName,
 	tests.HTTPRouteInvalidCrossNamespaceParentRef.ShortName,
-	tests.HTTPRouteInvalidNonExistentBackendRef.ShortName,
 	tests.HTTPRouteInvalidParentRefNotMatchingSectionName.ShortName,
 }
 


### PR DESCRIPTION
fix: 
https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-nonexistent-backendref.go#L36-L71

<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
