### PR TITLE
docs: update CRD doc template and remove dated info from configuration file doc

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -28,24 +28,3 @@ metadata:
 spec:
   controllerName: "apisix.apache.org/apisix-ingress-controller"
 ```
-
-### Addresses
-
-The `addresses` field records the status address of the Gateway.
-
-```yaml
-apiVersion: gateway.networking.k8s.io/v1
-  kind: Gateway
-  metadata:
-    name: gateway1
-  spec:
-    gatewayClassName: apisix
-    listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
-  status:
-    addresses:
-    - type: IPAddress
-      value: 172.18.0.4
-```

--- a/docs/crd/api.md
+++ b/docs/crd/api.md
@@ -157,7 +157,7 @@ _Base type:_ `LocalPolicyTargetReferenceWithSectionName`
 | `group` _[Group](#group)_ | Group is the group of the target resource. |
 | `kind` _[Kind](#kind)_ | Kind is kind of the target resource. |
 | `name` _[ObjectName](#objectname)_ | Name is the name of the target resource. |
-| `sectionName` _[SectionName](#sectionname)_ | SectionName is the name of a section within the target resource. When unspecified, this targetRef targets the entire resource. In the following resources, SectionName is interpreted as the following:<br /><br /> * Gateway: Listener name * HTTPRoute: HTTPRouteRule name * Service: Port name<br /><br /> If a SectionName is specified, but does not exist on the targeted object, the Policy must fail to attach, and the policy implementation should record a `ResolvedRefs` or similar Condition in the Policy's status. |
+| `sectionName` _[SectionName](#sectionname)_ | SectionName is the name of a section within the target resource. When unspecified, this targetRef targets the entire resource. In the following resources, SectionName is interpreted as the following:<br /><br /> • Gateway: Listener name<br /> • HTTPRoute: HTTPRouteRule name<br /> • Service: Port name<br /><br /> If a SectionName is specified, but does not exist on the targeted object, the Policy must fail to attach, and the policy implementation should record a `ResolvedRefs` or similar Condition in the Policy's status. |
 
 
 _Appears in:_

--- a/docs/crd/api.md
+++ b/docs/crd/api.md
@@ -1,10 +1,10 @@
 ---
-title: Resource Definitions API Reference
+title: Custom Resource Definitions API Reference
 slug: /reference/apisix-ingress-controller/crd-reference
 description: Explore detailed reference documentation for the custom resource definitions (CRDs) supported by the APISIX Ingress Controller.
 ---
 
-This document provides the API resource description for the APISIX Ingress Controller.
+This document provides the API resource description the API7 Ingress Controller custom resource definitions (CRDs).
 
 ## Packages
 - [apisix.apache.org/v1alpha1](#apisixapacheorgv1alpha1)

--- a/docs/template/gv_list.tpl
+++ b/docs/template/gv_list.tpl
@@ -2,12 +2,12 @@
 {{- $groupVersions := . -}}
 
 ---
-title: Resource Definitions API Reference
+title: Custom Resource Definitions API Reference
 slug: /reference/apisix-ingress-controller/crd-reference
 description: Explore detailed reference documentation for the custom resource definitions (CRDs) supported by the APISIX Ingress Controller.
 ---
 
-This document provides the API resource description for the APISIX Ingress Controller.
+This document provides the API resource description the API7 Ingress Controller custom resource definitions (CRDs).
 
 ## Packages
 {{- range $groupVersions }}

--- a/docs/template/type_members.tpl
+++ b/docs/template/type_members.tpl
@@ -4,6 +4,6 @@
 Please refer to the Kubernetes API documentation for details on the `metadata` field.
 {{- else -}}
 {{- /* First replace makes paragraphs separated, second merges lines in paragraphs. */ -}}
-{{ $field.Doc | replace "\n\n" "<br /><br />" |  replace "\n" " " }}
+{{ $field.Doc | replace "\n\n" "<br /><br />" |  replace "\n" " " | replace " *" "<br /> •" | replace "<br /><br /><br />" "<br /><br />" }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
1. Update CRD doc title and description in the template. Initially was planning to mention supported Gateway API and Ingress resources in the same doc; but now these content are separated.
2. Update template with more string substitution to avoid the need of manual editing after generation.
3. Remove unused Addresses section from `configure.md` which is a missed update from https://github.com/api7/api7-ingress-controller/pull/96

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
4. Doc is required for the feat PR
5. Use a new commit to resolve review instead of `push -f`
6. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
