### PR TITLE
feat: support conformance test for apisix

### DIFF
--- a/.github/workflows/apisix-conformance-test.yml.example
+++ b/.github/workflows/apisix-conformance-test.yml.example
@@ -1,0 +1,111 @@
+name: APISIX Conformance Test
+
+on:
+  push:
+    branches:
+      - master
+      - release-v2-dev
+  pull_request:
+    branches:
+      - master
+      - release-v2-dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go Env
+        id: go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.22"
+
+      - name: Install kind
+        run: |
+          go install sigs.k8s.io/kind@v0.23.0
+
+  conformance-test:
+    timeout-minutes: 60
+    needs: 
+      - prepare
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Go Env
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.22"
+
+      - name: Build images
+        env:
+          TAG: dev
+          ARCH: amd64
+          ENABLE_PROXY: "false"
+          BASE_IMAGE_TAG: "debug"
+        run: |
+          echo "building images..."
+          make build-image
+
+      - name: Launch Kind Cluster
+        run: |
+          make kind-up
+
+      - name: Install And Run Cloud Provider KIND
+        run: |
+          go install sigs.k8s.io/cloud-provider-kind@latest
+          nohup cloud-provider-kind > /tmp/kind-loadbalancer.log 2>&1 &
+  
+      - name: Install Gateway API And CRDs
+        run: |
+          make install
+
+      - name: Loading Docker Image to Kind Cluster
+        run: |
+          make kind-load-images
+
+      - name: Run Conformance Test
+        shell: bash
+        continue-on-error: true
+        run: |
+          make conformance-test-standalone
+      
+      - name: Get Logs from api7-ingress-controller
+        shell: bash
+        run: |
+          export KUBECONFIG=/tmp/apisix-ingress-cluster.kubeconfig
+          kubectl logs -n apisix-conformance-test -l app=apisix-ingress-controller
+
+      - name: Upload Gateway API Conformance Report
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: apisix-ingress-controller-conformance-report.yaml
+          path: apisix-ingress-controller-conformance-report.yaml
+
+      - name: Format Conformance Test Report
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo '# conformance test report' > report.md
+          echo '```yaml' >> report.md
+          cat apisix-ingress-controller-conformance-report.yaml >> report.md
+          echo '```' >> report.md
+
+      - name: Report Conformance Test Result to PR Comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-id: '${{ matrix.target }}'
+          message-path: |
+            report.md

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,11 @@ download-api7ee3-chart:
 conformance-test:
 	DASHBOARD_VERSION=$(DASHBOARD_VERSION) go test -v ./test/conformance -tags=conformance -timeout 60m
 
+.PHONY: conformance-test-standalone
+conformance-test-standalone:
+	@kind get kubeconfig --name $(KIND_NAME) > $$KUBECONFIG
+	go test -v ./test/conformance/apisix -tags=conformance -timeout 60m
+
 .PHONY: lint
 lint: sort-import golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run

--- a/test/conformance/apisix/conformance_test.go
+++ b/test/conformance/apisix/conformance_test.go
@@ -1,0 +1,78 @@
+//go:build conformance
+// +build conformance
+
+package conformance
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/gateway-api/conformance"
+	conformancev1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/tests"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+	"sigs.k8s.io/yaml"
+)
+
+var skippedTestsForSSL = []string{
+	// Reason: https://github.com/kubernetes-sigs/gateway-api/blob/5c5fc388829d24e8071071b01e8313ada8f15d9f/conformance/utils/suite/suite.go#L358.  SAN includes '*'
+	tests.HTTPRouteHTTPSListener.ShortName,
+	tests.HTTPRouteRedirectPortAndScheme.ShortName,
+}
+
+// TODO: HTTPRoute hostname intersection and listener hostname matching
+
+var gatewaySupportedFeatures = []features.FeatureName{
+	features.SupportGateway,
+	features.SupportHTTPRoute,
+	// features.SupportHTTPRouteMethodMatching,
+	// features.SupportHTTPRouteResponseHeaderModification,
+	// features.SupportHTTPRouteRequestMirror,
+	// features.SupportHTTPRouteBackendRequestHeaderModification,
+	// features.SupportHTTPRouteHostRewrite,
+}
+
+func TestGatewayAPIConformance(t *testing.T) {
+	flag.Parse()
+
+	opts := conformance.DefaultOptions(t)
+	opts.Debug = true
+	opts.CleanupBaseResources = true
+	opts.GatewayClassName = gatewayClassName
+	opts.SupportedFeatures = sets.New(gatewaySupportedFeatures...)
+	opts.SkipTests = skippedTestsForSSL
+	opts.Implementation = conformancev1.Implementation{
+		Organization: "APISIX",
+		Project:      "apisix-ingress-controller",
+		URL:          "https://github.com/apache/apisix-ingress-controller.git",
+		Version:      "v2.0.0",
+	}
+	opts.ConformanceProfiles = sets.New(suite.GatewayHTTPConformanceProfileName)
+
+	cSuite, err := suite.NewConformanceTestSuite(opts)
+	require.NoError(t, err)
+
+	t.Log("starting the gateway conformance test suite")
+	cSuite.Setup(t, tests.ConformanceTests)
+
+	if err := cSuite.Run(t, tests.ConformanceTests); err != nil {
+		t.Fatalf("failed to run the gateway conformance test suite: %v", err)
+	}
+
+	const reportFileName = "apisix-ingress-controller-conformance-report.yaml"
+	report, err := cSuite.Report()
+	if err != nil {
+		t.Fatalf("failed to get the gateway conformance test report: %v", err)
+	}
+
+	rawReport, err := yaml.Marshal(report)
+	if err != nil {
+		t.Fatalf("failed to marshal the gateway conformance test report: %v", err)
+	}
+	// Save report in the root of the repository, file name is in .gitignore.
+	require.NoError(t, os.WriteFile("../../../"+reportFileName, rawReport, 0o600))
+}

--- a/test/conformance/apisix/suite_test.go
+++ b/test/conformance/apisix/suite_test.go
@@ -26,6 +26,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
+	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
 )
 
 var gatewayClassName = "apisix"
@@ -117,7 +118,10 @@ func TestMain(m *testing.M) {
 	RegisterFailHandler(Fail)
 	f := framework.NewFramework()
 
-	f.BeforeSuite()
+	// init newDeployer function
+	scaffold.NewDeployer = func(s *scaffold.Scaffold) scaffold.Deployer {
+		return scaffold.NewAPISIXDeployer(s)
+	}
 
 	// Check and delete specific namespaces if they exist
 	kubectl := k8s.NewKubectlOptions("", "", "default")
@@ -130,22 +134,20 @@ func TestMain(m *testing.M) {
 	k8s.CreateNamespace(GinkgoT(), kubectl, namespace)
 	defer k8s.DeleteNamespace(GinkgoT(), kubectl, namespace)
 
-	gatewayGroupId := f.CreateNewGatewayGroupWithIngress()
-	adminKey := f.GetAdminKey(gatewayGroupId)
-
-	svc := f.DeployGateway(framework.API7DeployOptions{
-		Namespace:              namespace,
-		GatewayGroupID:         gatewayGroupId,
-		DPManagerEndpoint:      framework.DPManagerTLSEndpoint,
-		SetEnv:                 true,
-		SSLKey:                 framework.TestKey,
-		SSLCert:                framework.TestCert,
-		TLSEnabled:             true,
-		ForIngressGatewayGroup: true,
-		ServiceType:            "LoadBalancer",
-		ServiceHTTPPort:        80,
-		ServiceHTTPSPort:       443,
+	s := scaffold.NewScaffold(&scaffold.Options{
+		ControllerName:    "apisix.apache.org/apisix-ingress-controller",
+		SkipHooks:         true,
+		APISIXAdminAPIKey: getEnvOrDefault("APISIX_ADMIN_KEY", "edd1c9f034335f136f87ad84b625c8f1"),
 	})
+
+	s.Deployer.DeployDataplane(scaffold.DeployDataplaneOptions{
+		Namespace:         namespace,
+		SkipCreateTunnels: true,
+		ServiceType:       "LoadBalancer",
+		ServiceHTTPPort:   80,
+		ServiceHTTPSPort:  443,
+	})
+	svc := s.GetDataplaneService()
 
 	if len(svc.Status.LoadBalancer.Ingress) == 0 {
 		Fail("No LoadBalancer found for the service")
@@ -154,23 +156,23 @@ func TestMain(m *testing.M) {
 	address := svc.Status.LoadBalancer.Ingress[0].IP
 
 	f.DeployIngress(framework.IngressDeployOpts{
-		ControllerName: "apisix.apache.org/apisix-ingress-controller",
+		ControllerName: s.GetControllerName(),
 		Namespace:      namespace,
 		StatusAddress:  address,
 		InitSyncDelay:  1 * time.Minute,
 	})
 
+	adminEndpoint := fmt.Sprintf("http://%s.%s:9180", svc.Name, namespace)
+
 	defaultGatewayProxyOpts = GatewayProxyOpts{
 		StatusAddress: address,
-		AdminKey:      adminKey,
-		AdminEndpoint: framework.DashboardTLSEndpoint,
+		AdminKey:      s.AdminKey(),
+		AdminEndpoint: adminEndpoint,
 	}
 
 	patchGatewaysForConformanceTest(context.Background(), f.K8sClient)
 
 	code := m.Run()
-
-	f.AfterSuite()
 
 	os.Exit(code)
 }
@@ -250,4 +252,12 @@ func patchGatewaysForConformanceTest(ctx context.Context, k8sClient client.Clien
 			}
 		}
 	}()
+}
+
+// getEnvOrDefault returns environment variable value or default
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/test/e2e/framework/api7_gateway.go
+++ b/test/e2e/framework/api7_gateway.go
@@ -38,7 +38,7 @@ func init() {
 	DPSpecTpl = tpl
 }
 
-type DataPlaneDeployOptions struct {
+type API7DeployOptions struct {
 	Namespace string
 	Name      string
 
@@ -56,7 +56,7 @@ type DataPlaneDeployOptions struct {
 	ServiceHTTPSPort int
 }
 
-func (f *Framework) DeployGateway(opts DataPlaneDeployOptions) *corev1.Service {
+func (f *Framework) DeployGateway(opts API7DeployOptions) *corev1.Service {
 	if opts.ServiceName == "" {
 		opts.ServiceName = "api7ee3-apisix-gateway-mtls"
 	}

--- a/test/e2e/scaffold/deployer.go
+++ b/test/e2e/scaffold/deployer.go
@@ -14,8 +14,7 @@ package scaffold
 
 // Deployer defines the interface for deploying data plane components
 type Deployer interface {
-	// Deploy deploys components for scaffold
-	DeployDataplane()
+	DeployDataplane(opts DeployDataplaneOptions)
 	DeployIngress()
 	ScaleIngress(replicas int)
 	BeforeEach()
@@ -25,3 +24,11 @@ type Deployer interface {
 }
 
 var NewDeployer func(*Scaffold) Deployer
+
+type DeployDataplaneOptions struct {
+	Namespace         string
+	ServiceType       string
+	SkipCreateTunnels bool
+	ServiceHTTPPort   int
+	ServiceHTTPSPort  int
+}

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -45,6 +45,7 @@ type Options struct {
 
 	NamespaceSelectorLabel map[string][]string
 	DisableNamespaceLabel  bool
+	SkipHooks              bool
 }
 
 type Scaffold struct {
@@ -104,8 +105,10 @@ func NewScaffold(o *Options) *Scaffold {
 
 	s.Deployer = NewDeployer(s)
 
-	BeforeEach(s.Deployer.BeforeEach)
-	AfterEach(s.Deployer.AfterEach)
+	if !s.opts.SkipHooks {
+		BeforeEach(s.Deployer.BeforeEach)
+		AfterEach(s.Deployer.AfterEach)
+	}
 
 	return s
 }
@@ -402,4 +405,8 @@ func (s *Scaffold) GetGatewayHTTPSEndpoint(identifier string) (string, error) {
 	}
 
 	return resources.HttpsTunnel.Endpoint(), nil
+}
+
+func (s *Scaffold) GetDataplaneService() *corev1.Service {
+	return s.dataplaneService
 }


### PR DESCRIPTION
Because the apisix standalone mode has not been integrated yet, the consistency test cannot be passed normally. The yaml in .github has also not been enabled yet.

In order to support the direct invocation of the `DeployDataplane` function in the conformance test, I added a configuration structure `DeployDataplaneOptions` to override the existing configuration.