### PR TITLE
fix: add `GetAdminEndpoint` method for deployer

### DIFF
--- a/test/e2e/crds/backendtrafficpolicy.go
+++ b/test/e2e/crds/backendtrafficpolicy.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
 	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
 )
 
@@ -216,7 +215,7 @@ spec:
 `
 	var beforeEach = func() {
 		By("create GatewayProxy")
-		gatewayProxy := fmt.Sprintf(defaultGatewayProxy, framework.DashboardTLSEndpoint, s.AdminKey())
+		gatewayProxy := fmt.Sprintf(defaultGatewayProxy, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 		err := s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
 		Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 

--- a/test/e2e/crds/consumer.go
+++ b/test/e2e/crds/consumer.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
 	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
 )
 
@@ -494,7 +493,7 @@ spec:
 				Status(404)
 
 			By("update GatewayProxy with new admin key")
-			updatedProxy := fmt.Sprintf(updatedGatewayProxy, framework.DashboardTLSEndpoint, resources.AdminAPIKey)
+			updatedProxy := fmt.Sprintf(updatedGatewayProxy, s.Deployer.GetAdminEndpoint(resources.DataplaneService), resources.AdminAPIKey)
 			err = s.CreateResourceFromString(updatedProxy)
 			Expect(err).NotTo(HaveOccurred(), "updating GatewayProxy")
 			time.Sleep(5 * time.Second)

--- a/test/e2e/gatewayapi/controller.go
+++ b/test/e2e/gatewayapi/controller.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
 	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
 )
 
@@ -101,7 +100,7 @@ metadata:
 		By(fmt.Sprintf("create GatewayClass for controller %s", s.GetControllerName()))
 
 		By("create GatewayProxy")
-		gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+		gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 		err = s.CreateResourceFromStringWithNamespace(gatewayProxy, gatewayName)
 		Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 		time.Sleep(5 * time.Second)

--- a/test/e2e/gatewayapi/gateway.go
+++ b/test/e2e/gatewayapi/gateway.go
@@ -107,7 +107,7 @@ spec:
 
 		It("Create Gateway", func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 			err := s.CreateResourceFromString(gatewayProxy)
 			Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 			time.Sleep(5 * time.Second)
@@ -150,7 +150,7 @@ spec:
 	Context("Gateway SSL", func() {
 		It("Check if SSL resource was created", func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 			err := s.CreateResourceFromString(gatewayProxy)
 			Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 			time.Sleep(5 * time.Second)
@@ -211,7 +211,7 @@ spec:
 		Context("Gateway SSL with and without hostname", func() {
 			It("Check if SSL resource was created and updated", func() {
 				By("create GatewayProxy")
-				gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+				gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 				err := s.CreateResourceFromString(gatewayProxy)
 				Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 				time.Sleep(5 * time.Second)

--- a/test/e2e/gatewayapi/gatewayproxy.go
+++ b/test/e2e/gatewayapi/gatewayproxy.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
 	"github.com/apache/apisix-ingress-controller/test/e2e/scaffold"
 )
 
@@ -214,7 +213,7 @@ spec:
 		Expect(gcYaml).To(ContainSubstring("message: the gatewayclass has been accepted by the apisix-ingress-controller"), "checking GatewayClass condition message")
 
 		By("Create GatewayProxy with enabled plugin")
-		err = s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithEnabledPlugin, framework.DashboardTLSEndpoint, s.AdminKey()))
+		err = s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithEnabledPlugin, s.Deployer.GetAdminEndpoint(), s.AdminKey()))
 		Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy with enabled plugin")
 		time.Sleep(5 * time.Second)
 
@@ -234,7 +233,7 @@ spec:
 		By("Clean up resources")
 		_ = s.DeleteResourceFromString(fmt.Sprintf(httpRouteForTest, "apisix"))
 		_ = s.DeleteResourceFromString(fmt.Sprintf(gatewayWithProxy, gatewayClassName))
-		_ = s.DeleteResourceFromString(fmt.Sprintf(gatewayProxyWithEnabledPlugin, framework.DashboardTLSEndpoint, s.AdminKey()))
+		_ = s.DeleteResourceFromString(fmt.Sprintf(gatewayProxyWithEnabledPlugin, s.Deployer.GetAdminEndpoint(), s.AdminKey()))
 	})
 
 	Context("Test Gateway with enabled GatewayProxy plugin", func() {
@@ -252,7 +251,7 @@ spec:
 			resp.Header("X-Proxy-Test").IsEqual("enabled")
 
 			By("Update GatewayProxy with disabled plugin")
-			err := s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithDisabledPlugin, framework.DashboardTLSEndpoint, s.AdminKey()))
+			err := s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithDisabledPlugin, s.Deployer.GetAdminEndpoint(), s.AdminKey()))
 			Expect(err).NotTo(HaveOccurred(), "updating GatewayProxy with disabled plugin")
 			time.Sleep(5 * time.Second)
 
@@ -277,7 +276,7 @@ spec:
 
 		It("Should work OK with error-page", func() {
 			By("Update GatewayProxy with PluginMetadata")
-			err = s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithPluginMetadata0, framework.DashboardTLSEndpoint, s.AdminKey()))
+			err = s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithPluginMetadata0, s.Deployer.GetAdminEndpoint(), s.AdminKey()))
 			Expect(err).ShouldNot(HaveOccurred())
 			time.Sleep(5 * time.Second)
 
@@ -293,7 +292,7 @@ spec:
 				Body().Contains("404 from plugin metadata")
 
 			By("Update GatewayProxy with PluginMetadata")
-			err = s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithPluginMetadata1, framework.DashboardTLSEndpoint, s.AdminKey()))
+			err = s.CreateResourceFromString(fmt.Sprintf(gatewayProxyWithPluginMetadata1, s.Deployer.GetAdminEndpoint(), s.AdminKey()))
 			Expect(err).ShouldNot(HaveOccurred())
 			time.Sleep(5 * time.Second)
 
@@ -306,7 +305,7 @@ spec:
 				Body().Contains(`{"error_msg":"404 Route Not Found"}`)
 
 			By("Delete GatewayProxy")
-			err = s.DeleteResourceFromString(fmt.Sprintf(gatewayProxyWithPluginMetadata0, framework.DashboardTLSEndpoint, s.AdminKey()))
+			err = s.DeleteResourceFromString(fmt.Sprintf(gatewayProxyWithPluginMetadata0, s.Deployer.GetAdminEndpoint(), s.AdminKey()))
 			Expect(err).ShouldNot(HaveOccurred())
 			time.Sleep(5 * time.Second)
 

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -123,7 +123,7 @@ spec:
 
 	var beforeEachHTTP = func() {
 		By("create GatewayProxy")
-		gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+		gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 		err := s.CreateResourceFromString(gatewayProxy)
 		Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 		time.Sleep(5 * time.Second)
@@ -154,7 +154,7 @@ spec:
 
 	var beforeEachHTTPS = func() {
 		By("create GatewayProxy")
-		gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+		gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 		err := s.CreateResourceFromString(gatewayProxy)
 		Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 		time.Sleep(5 * time.Second)
@@ -322,7 +322,7 @@ spec:
 			Expect(gcyaml).To(ContainSubstring(`status: "True"`), "checking additional GatewayClass condition status")
 			Expect(gcyaml).To(ContainSubstring("message: the gatewayclass has been accepted by the apisix-ingress-controller"), "checking additional GatewayClass condition message")
 
-			additionalGatewayProxy := fmt.Sprintf(additionalGatewayProxyYaml, framework.DashboardTLSEndpoint, resources.AdminAPIKey)
+			additionalGatewayProxy := fmt.Sprintf(additionalGatewayProxyYaml, s.Deployer.GetAdminEndpoint(resources.DataplaneService), resources.AdminAPIKey)
 			err = s.CreateResourceFromStringWithNamespace(additionalGatewayProxy, additionalNamespace)
 			Expect(err).NotTo(HaveOccurred(), "creating additional GatewayProxy")
 
@@ -1688,7 +1688,7 @@ spec:
 				Status(404)
 
 			By("update GatewayProxy with new admin key")
-			updatedProxy := fmt.Sprintf(updatedGatewayProxy, framework.DashboardTLSEndpoint, resources.AdminAPIKey)
+			updatedProxy := fmt.Sprintf(updatedGatewayProxy, s.Deployer.GetAdminEndpoint(resources.DataplaneService), resources.AdminAPIKey)
 			err = s.CreateResourceFromString(updatedProxy)
 			Expect(err).NotTo(HaveOccurred(), "updating GatewayProxy")
 			time.Sleep(5 * time.Second)

--- a/test/e2e/ingress/ingress.go
+++ b/test/e2e/ingress/ingress.go
@@ -67,7 +67,7 @@ spec:
 	Context("Ingress TLS", func() {
 		It("Check if SSL resource was created", func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 
 			By("create GatewayProxy")
 			err := s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
@@ -202,7 +202,7 @@ spec:
 
 		It("Test IngressClass Selection", func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 			err := s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
 			Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 			time.Sleep(5 * time.Second)
@@ -227,7 +227,7 @@ spec:
 
 		It("Proxy External Service", func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 			err := s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
 			Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 			time.Sleep(5 * time.Second)
@@ -252,7 +252,7 @@ spec:
 
 		It("Delete Ingress during restart", func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 			err := s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
 			Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 			time.Sleep(5 * time.Second)
@@ -434,7 +434,7 @@ spec:
 
 		It("Test IngressClass with GatewayProxy", func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 
 			By("create GatewayProxy")
 			err := s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
@@ -477,7 +477,7 @@ stringData:
 			time.Sleep(5 * time.Second)
 
 			By("create GatewayProxy with Secret reference")
-			gatewayProxy := fmt.Sprintf(gatewayProxyWithSecretYaml, framework.DashboardTLSEndpoint)
+			gatewayProxy := fmt.Sprintf(gatewayProxyWithSecretYaml, s.Deployer.GetAdminEndpoint())
 			err = s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
 			Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy with Secret")
 			time.Sleep(5 * time.Second)
@@ -520,7 +520,7 @@ spec:
         type: AdminKey
         adminKey:
           value: "%s"
-`, framework.DashboardTLSEndpoint, s.AdminKey())
+`, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 		}
 
 		const ingressClassSpec = `
@@ -806,7 +806,7 @@ spec:
 
 		BeforeEach(func() {
 			By("create GatewayProxy")
-			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, framework.DashboardTLSEndpoint, s.AdminKey())
+			gatewayProxy := fmt.Sprintf(gatewayProxyYaml, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 			err := s.CreateResourceFromStringWithNamespace(gatewayProxy, "default")
 			Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 			time.Sleep(5 * time.Second)
@@ -848,7 +848,7 @@ spec:
 			Expect(exists).To(BeTrue(), "additional gateway group should exist")
 
 			By("update GatewayProxy with new admin key")
-			updatedProxy := fmt.Sprintf(updatedGatewayProxy, framework.DashboardTLSEndpoint, resources.AdminAPIKey)
+			updatedProxy := fmt.Sprintf(updatedGatewayProxy, s.Deployer.GetAdminEndpoint(resources.DataplaneService), resources.AdminAPIKey)
 			err = s.CreateResourceFromStringWithNamespace(updatedProxy, "default")
 			Expect(err).NotTo(HaveOccurred(), "updating GatewayProxy")
 			time.Sleep(5 * time.Second)
@@ -940,7 +940,7 @@ spec:
 			Expect(err).NotTo(HaveOccurred(), "creating secret")
 
 			By("create GatewayProxy")
-			err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(gatewayProxySpec, framework.DashboardTLSEndpoint), s.Namespace())
+			err = s.CreateResourceFromStringWithNamespace(fmt.Sprintf(gatewayProxySpec, s.Deployer.GetAdminEndpoint()), s.Namespace())
 			Expect(err).NotTo(HaveOccurred(), "creating gateway proxy")
 
 			By("create IngressClass")

--- a/test/e2e/scaffold/api7_deployer.go
+++ b/test/e2e/scaffold/api7_deployer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 	. "github.com/onsi/gomega"    //nolint:staticcheck
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/apache/apisix-ingress-controller/pkg/dashboard"
@@ -296,4 +297,9 @@ func (s *API7Deployer) CleanupAdditionalGateway(gatewayGroupID string) error {
 	delete(s.additionalGateways, gatewayGroupID)
 
 	return err
+}
+
+func (s *API7Deployer) GetAdminEndpoint(_ ...*corev1.Service) string {
+	// always return the default dashboard endpoint
+	return framework.DashboardTLSEndpoint
 }

--- a/test/e2e/scaffold/apisix_deployer.go
+++ b/test/e2e/scaffold/apisix_deployer.go
@@ -336,3 +336,10 @@ func (s *APISIXDeployer) CleanupAdditionalGateway(identifier string) error {
 
 	return err
 }
+
+func (s *APISIXDeployer) GetAdminEndpoint(svc ...*corev1.Service) string {
+	if len(svc) == 0 {
+		return fmt.Sprintf("http://%s.%s:9180", s.dataplaneService.Name, s.dataplaneService.Namespace)
+	}
+	return fmt.Sprintf("http://%s.%s:9180", svc[0].Name, svc[0].Namespace)
+}

--- a/test/e2e/scaffold/deployer.go
+++ b/test/e2e/scaffold/deployer.go
@@ -12,6 +12,8 @@
 
 package scaffold
 
+import corev1 "k8s.io/api/core/v1"
+
 // Deployer defines the interface for deploying data plane components
 type Deployer interface {
 	// Deploy deploys components for scaffold
@@ -22,6 +24,7 @@ type Deployer interface {
 	AfterEach()
 	CreateAdditionalGateway(namePrefix string) (string, string, error)
 	CleanupAdditionalGateway(identifier string) error
+	GetAdminEndpoint(...*corev1.Service) string
 }
 
 var NewDeployer func(*Scaffold) Deployer

--- a/test/e2e/scaffold/k8s.go
+++ b/test/e2e/scaffold/k8s.go
@@ -201,7 +201,7 @@ func (s *Scaffold) ApplyDefaultGatewayResource(
 	defaultHTTPRoute string,
 ) {
 	By("create GatewayProxy")
-	gatewayProxy := fmt.Sprintf(defaultGatewayProxy, framework.DashboardTLSEndpoint, s.AdminKey())
+	gatewayProxy := fmt.Sprintf(defaultGatewayProxy, s.Deployer.GetAdminEndpoint(), s.AdminKey())
 	err := s.CreateResourceFromString(gatewayProxy)
 	Expect(err).NotTo(HaveOccurred(), "creating GatewayProxy")
 	time.Sleep(5 * time.Second)

--- a/test/e2e/scaffold/scaffold.go
+++ b/test/e2e/scaffold/scaffold.go
@@ -81,6 +81,10 @@ type GatewayResources struct {
 	AdminAPIKey      string
 }
 
+func (g *GatewayResources) GetAdminEndpoint() string {
+	return fmt.Sprintf("http://%s.%s:9180", g.DataplaneService.Name, g.DataplaneService.Namespace)
+}
+
 func (s *Scaffold) AdminKey() string {
 	return s.opts.APISIXAdminAPIKey
 }


### PR DESCRIPTION
In many test cases, `framework.DashboardTLSEndpoint` was used directly. Now, the `GetAdminEndpoint` method is provided for processing, to adapt to different test modes.