### PR TITLE
fix: port name should always set to endpointPortName

### DIFF
--- a/pkg/utils/endpoints.go
+++ b/pkg/utils/endpoints.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/api7/gopkg/pkg/log"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -137,6 +139,8 @@ func ConvertEndpointsToEndpointSlice(ep *corev1.Endpoints) []discoveryv1.Endpoin
 			endpointSlices = append(endpointSlices, makeSlice("v6", discoveryv1.AddressTypeIPv6, ipv6Endpoints))
 		}
 	}
+
+	log.Debugw("Converted Endpoints to EndpointSlices", zap.Any("endpointSlices", endpointSlices))
 
 	return endpointSlices
 }

--- a/pkg/utils/endpoints_test.go
+++ b/pkg/utils/endpoints_test.go
@@ -308,7 +308,7 @@ func TestConvertEndpointsToEndpointSlice(t *testing.T) {
 			},
 			want: []discoveryv1.EndpointSlice{
 				createTestEndpointSlice("test-service-0-v4", discoveryv1.AddressTypeIPv4,
-					[]discoveryv1.EndpointPort{createPlainPort(80)},
+					[]discoveryv1.EndpointPort{createPlainPortWithEmptyName(80)},
 					[]discoveryv1.Endpoint{createEndpointWithHostname("192.168.1.1", "pod-1")}),
 			},
 		},
@@ -462,8 +462,9 @@ func createHTTPSPort(port int32) discoveryv1.EndpointPort {
 	}
 }
 
-func createPlainPort(port int32) discoveryv1.EndpointPort {
+func createPlainPortWithEmptyName(port int32) discoveryv1.EndpointPort {
 	return discoveryv1.EndpointPort{
+		Name:     ptr.To(""),
 		Port:     ptr.To(port),
 		Protocol: ptr.To(corev1.ProtocolTCP),
 	}

--- a/test/e2e/scaffold/httpbin.go
+++ b/test/e2e/scaffold/httpbin.go
@@ -83,8 +83,7 @@ spec:
   selector:
     app: httpbin-deployment-e2e-test
   ports:
-    - name: http
-      port: 80
+    - port: 80
       protocol: TCP
       targetPort: 80
   type: ClusterIP


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

The service port name may be empty, and it may report an error in the translate logic.

```go
func (t *Translator) translateEndpointSlice(portName *string, weight int, endpointSlices []discoveryv1.EndpointSlice, endpointFilter func(*discoveryv1.Endpoint) bool) adctypes.UpstreamNodes {
	var nodes adctypes.UpstreamNodes
	if len(endpointSlices) == 0 {
		return nodes
	}
	for _, endpointSlice := range endpointSlices {
		for _, port := range endpointSlice.Ports {
			if portName != nil && !ptr.Equal(portName, port.Name) {
				log.Debugf("translateEndpointSlice portName: %+v, port.Name: %+v\n", portName, port.Name)
				continue
			}
```

<img width="1060" height="39" alt="image" src="https://github.com/user-attachments/assets/ef7420ca-6464-4771-98da-a3fdfc4d8243" />


- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
