### PR TITLE
chore(ci): use github runner

### DIFF
--- a/.github/workflows/apisix-conformance-test.yml
+++ b/.github/workflows/apisix-conformance-test.yml
@@ -40,7 +40,7 @@ jobs:
         provider_type:
         - apisix-standalone
         - apisix
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/apisix-e2e-test.yml
+++ b/.github/workflows/apisix-e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
         - apisix.apache.org
         - networking.k8s.io
       fail-fast: false
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   prepare:
     name: Prepare
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 60
     needs: 
       - prepare
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   prepare:
     name: Prepare
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
   e2e-test:
     needs: 
       - prepare
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -27,7 +27,7 @@ on:
       - master
 jobs:
   check-license:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push-docker-v2-dev.yaml
+++ b/.github/workflows/push-docker-v2-dev.yaml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 jobs:
   docker:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -23,7 +23,7 @@ on:
       
 jobs:
   docker:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   update_release_draft:
     if: github.repository == 'api7/api7-ingress-controller'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Drafting release
         id: release_drafter

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ on:
       - 1.8.0
 jobs:
   run-test:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go Env


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:

Replace buildjet runner with github runner

Not including k8s 1.18 ci: https://github.com/apache/apisix-ingress-controller/blob/a0192695a567afae3240c396b46331cbff53c9e4/.github/workflows/e2e-test-k8s.yml#L37

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [ ] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
