### PR TITLE
docs: add ingressClassName to explicitly specify which ingress class should handle each resource

### DIFF
--- a/docs/en/latest/getting-started/key-authentication.md
+++ b/docs/en/latest/getting-started/key-authentication.md
@@ -218,6 +218,7 @@ metadata:
   namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
+  ingressClassName: apisix
   externalNodes:
   - type: Domain
     name: httpbin.org

--- a/docs/en/latest/getting-started/load-balancing.md
+++ b/docs/en/latest/getting-started/load-balancing.md
@@ -187,6 +187,7 @@ metadata:
   namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
+  ingressClassName: apisix
   scheme: https
   passHost: node
   externalNodes:
@@ -201,6 +202,7 @@ metadata:
   namespace: ingress-apisix
   name: mockapi7-external-domain
 spec:
+  ingressClassName: apisix
   scheme: https
   passHost: node
   externalNodes:

--- a/docs/en/latest/getting-started/rate-limiting.md
+++ b/docs/en/latest/getting-started/rate-limiting.md
@@ -177,6 +177,7 @@ metadata:
   namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
+  ingressClassName: apisix
   externalNodes:
   - type: Domain
     name: httpbin.org

--- a/docs/en/latest/reference/example.md
+++ b/docs/en/latest/reference/example.md
@@ -295,6 +295,7 @@ metadata:
   namespace: ingress-apisix
   name: get-ip
 spec:
+  ingressClassName: apisix
   rules:
   - http:
       paths:
@@ -318,6 +319,7 @@ metadata:
   namespace: ingress-apisix
   name: httpbin-external-domain
 spec:
+  ingressClassName: apisix
   externalNodes:
   - type: Domain
     name: httpbin.org


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [x] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

Should specify ingressClassName when there are multiple ingress controllers and ingress classes in the cluster.

https://github.com/apache/apisix-ingress-controller/pull/2573

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**
