### PR TITLE
fix(gatewayproxy): add stricter validation rules for provider (#2602) (3c808e2)

### DIFF
--- a/api/v1alpha1/gatewayproxy_types.go
+++ b/api/v1alpha1/gatewayproxy_types.go
@@ -34,7 +34,9 @@ type GatewayProxySpec struct {
 	// of GatewayProxy or Ingress resources for developers to access.
 	StatusAddress []string `json:"statusAddress,omitempty"`
 	// Provider configures the provider details.
-	Provider *GatewayProxyProvider `json:"provider,omitempty"`
+	//
+	// +kubebuilder:validation:required
+	Provider *GatewayProxyProvider `json:"provider"`
 	// Plugins configure global plugins.
 	Plugins []GatewayProxyPlugin `json:"plugins,omitempty"`
 	// PluginMetadata configures common configuration shared by all plugin instances of the same name.
@@ -83,6 +85,7 @@ type SecretKeySelector struct {
 }
 
 // AdminKeyAuth defines the admin key authentication configuration.
+// +kubebuilder:validation:XValidation:rule="has(self.value) != has(self.valueFrom)",message="exactly one of value or valueFrom must be specified"
 type AdminKeyAuth struct {
 	// Value sets the admin key value explicitly (not recommended for production).
 	// +optional
@@ -101,6 +104,8 @@ type AdminKeyValueFrom struct {
 }
 
 // ControlPlaneAuth defines the authentication configuration for control plane.
+//
+// +kubebuilder:validation:XValidation:rule="self.type == 'AdminKey' ? has(self.adminKey) : true",message="adminKey must be specified when type is AdminKey"
 type ControlPlaneAuth struct {
 	// Type specifies the type of authentication.
 	// Can only be `AdminKey`.

--- a/config/crd/bases/apisix.apache.org_gatewayproxies.yaml
+++ b/config/crd/bases/apisix.apache.org_gatewayproxies.yaml
@@ -103,6 +103,9 @@ spec:
                                     type: object
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of value or valueFrom must be specified
+                              rule: has(self.value) != has(self.valueFrom)
                           type:
                             description: |-
                               Type specifies the type of authentication.
@@ -113,6 +116,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: adminKey must be specified when type is AdminKey
+                          rule: 'self.type == ''AdminKey'' ? has(self.adminKey) :
+                            true'
                       endpoints:
                         description: Endpoints specifies the list of control plane
                           endpoints.
@@ -168,6 +175,8 @@ spec:
                 items:
                   type: string
                 type: array
+            required:
+            - provider
             type: object
         type: object
     served: true


### PR DESCRIPTION
<!-- backport:3c808e226a33c4355f5e254c10fe61b85c331f2f -->

## 🔄 Automated Backport

- Upstream commit: https://github.com/apache/apisix-ingress-controller/commit/3c808e226a33c4355f5e254c10fe61b85c331f2f
- Original title: fix(gatewayproxy): add stricter validation rules for provider (#2602)
- Original author: AlinsRan <alinsran@apache.org>

Please review and run the relevant validation before merging.

> Created automatically by backport-bot.