### PR TITLE
feat: support skip gatewayapi v1alpha2

### DIFF
--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -44,6 +44,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
+	pkgutils "github.com/apache/apisix-ingress-controller/pkg/utils"
 )
 
 // ConsumerReconciler  reconciles a Gateway object.
@@ -60,6 +61,10 @@ type ConsumerReconciler struct { //nolint:revive
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if config.ControllerConfig.DisableGatewayAPI || !pkgutils.HasAPIResource(mgr, &gatewayv1.Gateway{}) {
+		r.Log.Info("skipping Consumer controller setup as Gateway API is not available")
+		return nil
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Consumer{},
 			builder.WithPredicates(

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
+	pkgutils "github.com/apache/apisix-ingress-controller/pkg/utils"
 )
 
 // GatewayReconciler reconciles a Gateway object.
@@ -84,18 +85,6 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		).
 		Watches(
-			&gatewayv1alpha2.TCPRoute{},
-			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
-		).
-		Watches(
-			&gatewayv1alpha2.TLSRoute{},
-			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
-		).
-		Watches(
-			&gatewayv1alpha2.UDPRoute{},
-			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
-		).
-		Watches(
 			&v1alpha1.GatewayProxy{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForGatewayProxy),
 		).
@@ -108,6 +97,24 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		bdr.Watches(&v1beta1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
 			builder.WithPredicates(referenceGrantPredicates(KindGateway)),
+		)
+	}
+	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TCPRoute{}) {
+		bdr.Watches(
+			&gatewayv1alpha2.TCPRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
+		)
+	}
+	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TLSRoute{}) {
+		bdr.Watches(
+			&gatewayv1alpha2.TLSRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
+		)
+	}
+	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.UDPRoute{}) {
+		bdr.Watches(
+			&gatewayv1alpha2.UDPRoute{},
+			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
 


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

OpenShif does not allow additional installation of gateway API v1alph2, so it allows them to be skipped.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System now gracefully handles scenarios where the Gateway API is unavailable or disabled by skipping controller initialization when API resources are not detected. This improves startup reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->