### PR TITLE
fix: cannot use ingress when disabling gateway API

### DIFF
--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -155,7 +155,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.Get(ctx, req.NamespacedName, hr); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			if err := r.updateHTTPRoutePolicyStatusOnDeleting(ctx, req.NamespacedName); err != nil {
-				return ctrl.Result{}, err
+				r.Log.Error(err, "failed to update HTTPRoutePolicy status on HTTPRoute deleting", "httproute", req.NamespacedName)
 			}
 			hr.Namespace = req.Namespace
 			hr.Name = req.Name

--- a/internal/controller/httproutepolicy.go
+++ b/internal/controller/httproutepolicy.go
@@ -45,7 +45,8 @@ func (r *HTTPRouteReconciler) processHTTPRoutePolicies(tctx *provider.TranslateC
 		key  = indexer.GenIndexKeyWithGK(gatewayv1.GroupName, internaltypes.KindHTTPRoute, httpRoute.GetNamespace(), httpRoute.GetName())
 	)
 	if err := r.List(context.Background(), &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		return err
+		r.Log.Error(err, "failed to list HTTPRoutePolicies for HTTPRoute", "httproute", utils.NamespacedName(httpRoute))
+		return nil
 	}
 
 	if len(list.Items) == 0 {
@@ -109,7 +110,8 @@ func (r *HTTPRouteReconciler) updateHTTPRoutePolicyStatusOnDeleting(ctx context.
 		key  = indexer.GenIndexKeyWithGK(gatewayv1.GroupName, internaltypes.KindHTTPRoute, nn.Namespace, nn.Name)
 	)
 	if err := r.List(ctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		return err
+		r.Log.Error(err, "failed to list HTTPRoutePolicies for HTTPRoute", "httproute", nn)
+		return nil
 	}
 	var (
 		httpRoutes = make(map[types.NamespacedName]gatewayv1.HTTPRoute)
@@ -141,7 +143,8 @@ func (r *IngressReconciler) processHTTPRoutePolicies(tctx *provider.TranslateCon
 		key  = indexer.GenIndexKeyWithGK(networkingv1.GroupName, internaltypes.KindIngress, ingress.GetNamespace(), ingress.GetName())
 	)
 	if err := r.List(context.Background(), &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		return err
+		r.Log.Error(err, "failed to list HTTPRoutePolicies for Ingress", "ingress", utils.NamespacedName(ingress))
+		return nil
 	}
 
 	if len(list.Items) == 0 {
@@ -183,7 +186,8 @@ func (r *IngressReconciler) updateHTTPRoutePolicyStatusOnDeleting(ctx context.Co
 		key  = indexer.GenIndexKeyWithGK(networkingv1.GroupName, internaltypes.KindIngress, nn.Namespace, nn.Name)
 	)
 	if err := r.List(ctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		return err
+		r.Log.Error(err, "failed to list HTTPRoutePolicies for Ingress", "ingress", nn)
+		return nil
 	}
 	var (
 		ingress2ParentRef = make(map[types.NamespacedName]gatewayv1.ParentReference)

--- a/internal/controller/httproutepolicy.go
+++ b/internal/controller/httproutepolicy.go
@@ -45,8 +45,7 @@ func (r *HTTPRouteReconciler) processHTTPRoutePolicies(tctx *provider.TranslateC
 		key  = indexer.GenIndexKeyWithGK(gatewayv1.GroupName, internaltypes.KindHTTPRoute, httpRoute.GetNamespace(), httpRoute.GetName())
 	)
 	if err := r.List(context.Background(), &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		r.Log.Error(err, "failed to list HTTPRoutePolicies for HTTPRoute", "httproute", utils.NamespacedName(httpRoute))
-		return nil
+		return err
 	}
 
 	if len(list.Items) == 0 {
@@ -110,8 +109,7 @@ func (r *HTTPRouteReconciler) updateHTTPRoutePolicyStatusOnDeleting(ctx context.
 		key  = indexer.GenIndexKeyWithGK(gatewayv1.GroupName, internaltypes.KindHTTPRoute, nn.Namespace, nn.Name)
 	)
 	if err := r.List(ctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		r.Log.Error(err, "failed to list HTTPRoutePolicies for HTTPRoute", "httproute", nn)
-		return nil
+		return err
 	}
 	var (
 		httpRoutes = make(map[types.NamespacedName]gatewayv1.HTTPRoute)
@@ -143,8 +141,7 @@ func (r *IngressReconciler) processHTTPRoutePolicies(tctx *provider.TranslateCon
 		key  = indexer.GenIndexKeyWithGK(networkingv1.GroupName, internaltypes.KindIngress, ingress.GetNamespace(), ingress.GetName())
 	)
 	if err := r.List(context.Background(), &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		r.Log.Error(err, "failed to list HTTPRoutePolicies for Ingress", "ingress", utils.NamespacedName(ingress))
-		return nil
+		return err
 	}
 
 	if len(list.Items) == 0 {
@@ -186,8 +183,7 @@ func (r *IngressReconciler) updateHTTPRoutePolicyStatusOnDeleting(ctx context.Co
 		key  = indexer.GenIndexKeyWithGK(networkingv1.GroupName, internaltypes.KindIngress, nn.Namespace, nn.Name)
 	)
 	if err := r.List(ctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
-		r.Log.Error(err, "failed to list HTTPRoutePolicies for Ingress", "ingress", nn)
-		return nil
+		return err
 	}
 	var (
 		ingress2ParentRef = make(map[types.NamespacedName]gatewayv1.ParentReference)

--- a/internal/controller/indexer/indexer.go
+++ b/internal/controller/indexer/indexer.go
@@ -88,6 +88,7 @@ func SetupIndexer(mgr ctrl.Manager) error {
 		&networkingv1.IngressClass{}:      setupIngressClassIndexer,
 		&networkingv1beta1.IngressClass{}: setupIngressClassV1beta1Indexer,
 		&v1alpha1.BackendTrafficPolicy{}:  setupBackendTrafficPolicyIndexer,
+		&v1alpha1.HTTPRoutePolicy{}:       setHTTPRoutePolicyIndexer,
 	} {
 		if utils.HasAPIResource(mgr, resource) {
 			if err := setup(mgr); err != nil {
@@ -275,7 +276,10 @@ func setupHTTPRouteIndexer(mgr ctrl.Manager) error {
 	); err != nil {
 		return err
 	}
+	return nil
+}
 
+func setHTTPRoutePolicyIndexer(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
 		&v1alpha1.HTTPRoutePolicy{},
@@ -284,7 +288,6 @@ func setupHTTPRouteIndexer(mgr ctrl.Manager) error {
 	); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -143,7 +143,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.Get(ctx, req.NamespacedName, ingress); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			if err := r.updateHTTPRoutePolicyStatusOnDeleting(ctx, req.NamespacedName); err != nil {
-				return ctrl.Result{}, err
+				r.Log.Error(err, "failed to update HTTPRoutePolicy status on Ingress deleting", "ingress", req.NamespacedName)
 			}
 
 			// Ingress was deleted, clean up corresponding resources
@@ -212,7 +212,6 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// process HTTPRoutePolicy
 	if err := r.processHTTPRoutePolicies(tctx, ingress); err != nil {
 		r.Log.Error(err, "failed to process HTTPRoutePolicy", "ingress", ingress.Name)
-		return ctrl.Result{}, err
 	}
 
 	ProcessBackendTrafficPolicy(r.Client, r.Log, tctx)


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD or Tests

### What this PR does / why we need it:

When disabling the gateway API, the ingress resource cannot be used because the httproutepolicy does not have an index set.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [ ] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in request reconciliation to log errors while continuing operations instead of aborting.

* **Refactor**
  * Added indexer configuration for additional resource type to optimize query performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->