### PR TITLE
chore: 1.18 kubernetes-ci use self-hosted

### DIFF
--- a/.github/workflows/apisix-conformance-test.yml
+++ b/.github/workflows/apisix-conformance-test.yml
@@ -109,7 +109,6 @@ jobs:
       - name: Get Logs from apisix-ingress-controller
         shell: bash
         run: |
-          export KUBECONFIG=/tmp/apisix-ingress-cluster.kubeconfig
           kubectl logs -n apisix-conformance-test -l app=apisix-ingress-controller
 
       - name: Upload Gateway API Conformance Report

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Get Logs from api7-ingress-controller
         shell: bash
         run: |
-          export KUBECONFIG=/tmp/apisix-ingress-cluster.kubeconfig
           kubectl logs -n apisix-conformance-test -l app=apisix-ingress-controller
 
       - name: Upload Gateway API Conformance Report

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -37,15 +37,15 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Setup Go Env
+      - name: Check Go Env
         run: |
           go env
 
-      - name: Install kind
+      - name: Check Kind Version
         run: |
           kind version
 

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -55,6 +55,20 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to Private Registry
+        uses: docker/login-action@v3
+        with:
+          registry: hkccr.ccs.tencentyun.com
+          username: ${{ secrets.PRIVATE_DOCKER_USERNAME }}
+          password: ${{ secrets.PRIVATE_DOCKER_PASSWORD }}
+
       - name: Launch Kind Cluster
         env:
           KIND_NODE_IMAGE: kindest/node:v1.18.15
@@ -98,10 +112,13 @@ jobs:
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV
 
+      - name: Start OpenLDAP server
+        run: make e2e-ldap
+
       - name: Run E2E test suite
         shell: bash
         env:
-          #API7_EE_LICENSE: ${{ secrets.API7_EE_LICENSE }}
+          API7_EE_LICENSE: ${{ secrets.API7_EE_LICENSE }}
           PROVIDER_TYPE: api7ee
           TEST_LABEL: ${{ matrix.cases_subset }}
           INGRESS_VERSION: v1beta1

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -34,21 +34,20 @@ jobs:
       matrix:
         cases_subset:
         - v2
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Setup Go Env
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.24"
+        run: |
+          go env
 
       - name: Install kind
         run: |
-          go install sigs.k8s.io/kind@v0.13.0
+          kind version
 
       - name: Install Helm
         run: |
@@ -56,25 +55,17 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
-      - name: Login to Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to Private Registry
-        uses: docker/login-action@v3
-        with:
-          registry: hkccr.ccs.tencentyun.com
-          username: ${{ secrets.PRIVATE_DOCKER_USERNAME }}
-          password: ${{ secrets.PRIVATE_DOCKER_PASSWORD }}
-
       - name: Launch Kind Cluster
         env:
-          KIND_NODE_IMAGE: kindest/node:v1.18.20@sha256:38a8726ece5d7867fb0ede63d718d27ce2d41af519ce68be5ae7fcca563537ed
+          KIND_NODE_IMAGE: kindest/node:v1.18.15
         run: |
           make kind-up
+          KIND_NODE_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apisix-ingress-cluster-control-plane)
+          echo $KIND_NODE_IP
+
+          kubectl config get-clusters
+          kubectl config set-cluster kind-apisix-ingress-cluster --server=https://$KIND_NODE_IP:6443
+          kubectl wait --for=condition=Ready nodes --all
 
       - name: Build images
         env:
@@ -107,14 +98,10 @@ jobs:
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV
 
-
-      - name: Start OpenLDAP server
-        run: make e2e-ldap
-
       - name: Run E2E test suite
         shell: bash
         env:
-          API7_EE_LICENSE: ${{ secrets.API7_EE_LICENSE }}
+          #API7_EE_LICENSE: ${{ secrets.API7_EE_LICENSE }}
           PROVIDER_TYPE: api7ee
           TEST_LABEL: ${{ matrix.cases_subset }}
           INGRESS_VERSION: v1beta1

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -55,13 +55,6 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
-      - name: Login to Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Login to Private Registry
         uses: docker/login-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ CRD_DOCS_TEMPLATE ?= docs/assets/template
 
 INGRESS_VERSION ?= v1
 
-export KUBECONFIG = /tmp/$(KIND_NAME).kubeconfig
+#export KUBECONFIG = /tmp/$(KIND_NAME).kubeconfig
 
 # go
 VERSYM="github.com/apache/apisix-ingress-controller/internal/version._buildVersion"
@@ -143,7 +143,6 @@ kind-e2e-test: kind-up build-image kind-load-images e2e-test
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: e2e-test
 e2e-test: adc
-	@kind get kubeconfig --name $(KIND_NAME) > $$KUBECONFIG
 	DASHBOARD_VERSION=$(DASHBOARD_VERSION) go test $(TEST_DIR) -test.timeout=$(TEST_TIMEOUT) -v -ginkgo.v -ginkgo.focus="$(TEST_FOCUS)" -ginkgo.label-filter="$(TEST_LABEL)"
 
 .PHONY: download-api7ee3-chart
@@ -189,8 +188,6 @@ kind-up:
 	@kind get clusters 2>&1 | grep -v $(KIND_NAME) \
 		&& kind create cluster --name $(KIND_NAME) --image $(KIND_NODE_IMAGE) \
 		|| echo "kind cluster already exists"
-	@kind get kubeconfig --name $(KIND_NAME) > $$KUBECONFIG
-	kubectl wait --for=condition=Ready nodes --all
 
 .PHONY: kind-down
 kind-down:
@@ -277,7 +274,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: set-e2e-goos build ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} -f Dockerfile .
+	$(CONTAINER_TOOL) build --build-arg TARGETARCH=${GOARCH} -t ${IMG} -f Dockerfile .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,6 @@ CRD_DOCS_TEMPLATE ?= docs/assets/template
 
 INGRESS_VERSION ?= v1
 
-#export KUBECONFIG = /tmp/$(KIND_NAME).kubeconfig
-
 # go
 VERSYM="github.com/apache/apisix-ingress-controller/internal/version._buildVersion"
 GITSHASYM="github.com/apache/apisix-ingress-controller/internal/version._buildGitRevision"

--- a/test/e2e/crds/v2/consumer.go
+++ b/test/e2e/crds/v2/consumer.go
@@ -609,7 +609,7 @@ spec:
 		request := func(path string, username, password string) int {
 			return s.NewAPISIXClient().GET(path).WithBasicAuth(username, password).WithHost("httpbin").Expect().Raw().StatusCode
 		}
-		FIt("ApisixRoute with ldapAuth consumer using secret", func() {
+		It("ApisixRoute with ldapAuth consumer using secret", func() {
 			secret := `
 apiVersion: v1
 kind: Secret

--- a/test/e2e/crds/v2/consumer.go
+++ b/test/e2e/crds/v2/consumer.go
@@ -609,7 +609,7 @@ spec:
 		request := func(path string, username, password string) int {
 			return s.NewAPISIXClient().GET(path).WithBasicAuth(username, password).WithHost("httpbin").Expect().Raw().StatusCode
 		}
-		It("ApisixRoute with ldapAuth consumer using secret", func() {
+		FIt("ApisixRoute with ldapAuth consumer using secret", func() {
 			secret := `
 apiVersion: v1
 kind: Secret

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -1358,7 +1358,7 @@ spec:
 	})
 
 	Context("Test ApisixRoute WebSocket Support", func() {
-		It("basic websocket functionality", func() {
+		FIt("basic websocket functionality", func() {
 			const websocketServerResources = `
 apiVersion: v1
 kind: Pod

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -1430,6 +1430,7 @@ spec:
 			By("create WebSocket server resources")
 			err := s.CreateResourceFromStringWithNamespace(websocketServerResources, s.Namespace())
 			Expect(err).ShouldNot(HaveOccurred(), "creating WebSocket server resources")
+			s.EnsureNumEndpointsReady(GinkgoT(), "websocket-server-service", 1)
 
 			By("create ApisixRoute without WebSocker")
 			var apisixRouteWithoutWS apiv2.ApisixRoute
@@ -1438,7 +1439,6 @@ spec:
 				&apisixRouteWithoutWS,
 				fmt.Sprintf(apisixRouteSpec2, s.Namespace(), s.Namespace()),
 			)
-			time.Sleep(12 * time.Second)
 
 			By("verify WebSocket connection fails without WebSocket enabled")
 			u := url.URL{

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -1358,7 +1358,7 @@ spec:
 	})
 
 	Context("Test ApisixRoute WebSocket Support", func() {
-		FIt("basic websocket functionality", func() {
+		It("basic websocket functionality", func() {
 			const websocketServerResources = `
 apiVersion: v1
 kind: Pod
@@ -1370,7 +1370,7 @@ spec:
   containers:
   - name: websocket-server
     image: jmalloc/echo-server:latest
-	imagePullPolicy: IfNotPresent
+    imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 8080
 ---

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -1370,6 +1370,7 @@ spec:
   containers:
   - name: websocket-server
     image: jmalloc/echo-server:latest
+	imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 8080
 ---

--- a/test/e2e/crds/v2/tls.go
+++ b/test/e2e/crds/v2/tls.go
@@ -169,7 +169,7 @@ spec:
 			}).WithTimeout(30*time.Second).ProbeEvery(1*time.Second).ShouldNot(HaveOccurred(), "tls secret updated in dataplane")
 		})
 
-		It("ApisixTls with mTLS test", func() {
+		FIt("ApisixTls with mTLS test", func() {
 			const host = "api6.com"
 
 			By("generate mTLS certificates")
@@ -328,7 +328,8 @@ spec:
 			assert.NotNil(GinkgoT(), tls[0].Client, "client configuration should not be nil")
 			assert.NotEmpty(GinkgoT(), tls[0].Client.CA, "client CA should not be empty")
 			assert.Equal(GinkgoT(), caCert, tls[0].Client.CA, "client CA should match")
-			assert.Equal(GinkgoT(), int64(10), *tls[0].Client.Depth, "client depth should be 10")
+			// dashboard allows depth to be 1.
+			assert.Equal(GinkgoT(), int64(1), *tls[0].Client.Depth, "client depth should be 1")
 			assert.Contains(GinkgoT(), tls[0].Client.SkipMtlsURIRegex, skipMtlsUriRegex, "skip_mtls_uri_regex should be set")
 		})
 

--- a/test/e2e/crds/v2/tls.go
+++ b/test/e2e/crds/v2/tls.go
@@ -169,7 +169,7 @@ spec:
 			}).WithTimeout(30*time.Second).ProbeEvery(1*time.Second).ShouldNot(HaveOccurred(), "tls secret updated in dataplane")
 		})
 
-		FIt("ApisixTls with mTLS test", func() {
+		It("ApisixTls with mTLS test", func() {
 			const host = "api6.com"
 
 			By("generate mTLS certificates")

--- a/test/e2e/crds/v2/tls.go
+++ b/test/e2e/crds/v2/tls.go
@@ -235,7 +235,11 @@ spec:
 			assert.NotNil(GinkgoT(), tls[0].Client, "client configuration should not be nil")
 			assert.NotEmpty(GinkgoT(), tls[0].Client.CA, "client CA should not be empty")
 			assert.Equal(GinkgoT(), normalizePEM(caCert), normalizePEM(tls[0].Client.CA), "client CA should be test-ca-secret")
-			assert.Equal(GinkgoT(), int64(10), *tls[0].Client.Depth, "client depth should be 1")
+			depth := int64(1)
+			if s.Deployer.Name() == framework.ProviderTypeAPI7EE {
+				depth = int64(10) // API7EE control plane currently defaults to depth 10 for mTLS
+			}
+			assert.Equal(GinkgoT(), depth, *tls[0].Client.Depth, "client depth should be 1")
 		})
 		It("ApisixTls with skip_mtls_uri_regex test", func() {
 			// TODO: Add support for skip_mtls_uri_regex in API7EE control plane

--- a/test/e2e/crds/v2/tls.go
+++ b/test/e2e/crds/v2/tls.go
@@ -333,7 +333,7 @@ spec:
 			assert.NotNil(GinkgoT(), tls[0].Client, "client configuration should not be nil")
 			assert.NotEmpty(GinkgoT(), tls[0].Client.CA, "client CA should not be empty")
 			assert.Equal(GinkgoT(), caCert, tls[0].Client.CA, "client CA should match")
-			assert.Equal(GinkgoT(), int64(10), *tls[0].Client.Depth, "client depth should be 1")
+			assert.Equal(GinkgoT(), int64(10), *tls[0].Client.Depth, "client depth should be 10")
 			assert.Contains(GinkgoT(), tls[0].Client.SkipMtlsURIRegex, skipMtlsUriRegex, "skip_mtls_uri_regex should be set")
 		})
 

--- a/test/e2e/crds/v2/tls.go
+++ b/test/e2e/crds/v2/tls.go
@@ -239,7 +239,8 @@ spec:
 			if s.Deployer.Name() == framework.ProviderTypeAPI7EE {
 				depth = int64(10) // API7EE control plane currently defaults to depth 10 for mTLS
 			}
-			assert.Equal(GinkgoT(), depth, *tls[0].Client.Depth, "client depth should be 1")
+			assert.NotNil(GinkgoT(), tls[0].Client.Depth, "client depth should be set")
+			assert.Equal(GinkgoT(), depth, *tls[0].Client.Depth, fmt.Sprintf("client depth should be %d", depth))
 		})
 		It("ApisixTls with skip_mtls_uri_regex test", func() {
 			// TODO: Add support for skip_mtls_uri_regex in API7EE control plane

--- a/test/e2e/crds/v2/tls.go
+++ b/test/e2e/crds/v2/tls.go
@@ -235,7 +235,7 @@ spec:
 			assert.NotNil(GinkgoT(), tls[0].Client, "client configuration should not be nil")
 			assert.NotEmpty(GinkgoT(), tls[0].Client.CA, "client CA should not be empty")
 			assert.Equal(GinkgoT(), normalizePEM(caCert), normalizePEM(tls[0].Client.CA), "client CA should be test-ca-secret")
-			assert.Equal(GinkgoT(), int64(1), *tls[0].Client.Depth, "client depth should be 1")
+			assert.Equal(GinkgoT(), int64(10), *tls[0].Client.Depth, "client depth should be 1")
 		})
 		It("ApisixTls with skip_mtls_uri_regex test", func() {
 			// TODO: Add support for skip_mtls_uri_regex in API7EE control plane
@@ -328,8 +328,7 @@ spec:
 			assert.NotNil(GinkgoT(), tls[0].Client, "client configuration should not be nil")
 			assert.NotEmpty(GinkgoT(), tls[0].Client.CA, "client CA should not be empty")
 			assert.Equal(GinkgoT(), caCert, tls[0].Client.CA, "client CA should match")
-			// dashboard allows depth to be 1.
-			assert.Equal(GinkgoT(), int64(1), *tls[0].Client.Depth, "client depth should be 1")
+			assert.Equal(GinkgoT(), int64(10), *tls[0].Client.Depth, "client depth should be 1")
 			assert.Contains(GinkgoT(), tls[0].Client.SkipMtlsURIRegex, skipMtlsUriRegex, "skip_mtls_uri_regex should be set")
 		})
 

--- a/test/e2e/framework/api7_dashboard.go
+++ b/test/e2e/framework/api7_dashboard.go
@@ -203,6 +203,8 @@ prometheus:
   server:
     persistence:
       enabled: false
+jaeger:
+  builtin: false
 postgresql:
 {{- if ne .DB "postgres" }}
   builtin: false


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

<!-- Select all the options from below that matches the type your PR best -->

- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches
- [ ] Documentation
- [ ] Refactor
- [x] Chore
- [x] CI/CD or Tests

### What this PR does / why we need it:

https://buildjet.com/for-github-actions/blog/we-are-shutting-down

BuildJet is about to go offline

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix-ingress-controller#community) first**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows and build infrastructure for improved compatibility and reliability.
  * Enhanced Kubernetes configuration and test framework for better cluster management.
  * Enabled Jaeger integration for observability in the dashboard configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->