### PR TITLE
fix: remove redundant route.Hosts to prevent false diffs in ADC sync

### DIFF
--- a/.github/workflows/apisix-e2e-test.yml
+++ b/.github/workflows/apisix-e2e-test.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.js adc.js
+          docker cp adc-temp:main.cjs adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.js adc.js
+          docker cp adc-temp:main.cjs adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -102,7 +102,7 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.js adc.js
+          docker cp adc-temp:main.cjs adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/internal/adc/translator/apisixroute.go
+++ b/internal/adc/translator/apisixroute.go
@@ -192,7 +192,6 @@ func (t *Translator) buildRoute(ar *apiv2.ApisixRoute, service *adc.Service, rul
 		route.EnableWebsocket = *enableWebsocket
 	}
 	route.FilterFunc = rule.Match.FilterFunc
-	route.Hosts = rule.Match.Hosts
 	route.Methods = rule.Match.Methods
 	route.Plugins = plugins
 	route.Priority = ptr.To(int64(rule.Priority))

--- a/internal/adc/translator/apisixroute_test.go
+++ b/internal/adc/translator/apisixroute_test.go
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	adc "github.com/apache/apisix-ingress-controller/api/adc"
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+)
+
+func TestBuildRoute_HostsNotSet(t *testing.T) {
+	translator := NewTranslator(logr.Discard())
+
+	ar := &apiv2.ApisixRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+
+	service := &adc.Service{}
+	rule := apiv2.ApisixRouteHTTP{
+		Name: "rule1",
+		Match: apiv2.ApisixRouteHTTPMatch{
+			Hosts: []string{"example.com", "foo.com"},
+			Paths: []string{"/api/*"},
+		},
+	}
+
+	var enableWebsocket *bool
+	translator.buildRoute(ar, service, rule, nil, nil, nil, &enableWebsocket)
+
+	assert.Len(t, service.Routes, 1)
+	route := service.Routes[0]
+	// route.Hosts should NOT be set — hosts belong on Service, not Route.
+	// Setting hosts on Route causes false diffs in backends that don't
+	// support route-level hosts (e.g., API7 EE).
+	assert.Nil(t, route.Hosts, "route.Hosts should not be set; hosts should only be on Service")
+	assert.Equal(t, []string{"/api/*"}, route.Uris)
+}
+
+func TestBuildService_HostsSet(t *testing.T) {
+	translator := NewTranslator(logr.Discard())
+
+	ar := &apiv2.ApisixRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+
+	rule := apiv2.ApisixRouteHTTP{
+		Name: "rule1",
+		Match: apiv2.ApisixRouteHTTPMatch{
+			Hosts: []string{"example.com", "foo.com"},
+			Paths: []string{"/api/*"},
+		},
+	}
+
+	service := translator.buildService(ar, rule, 0)
+
+	// service.Hosts SHOULD be set — this is the canonical location for hosts.
+	assert.Equal(t, []string{"example.com", "foo.com"}, service.Hosts)
+}

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -141,7 +141,7 @@ spec:
 				applier.MustApplyAPIv2(types.NamespacedName{Namespace: s.Namespace(), Name: "default"},
 					&apisixRoute, fmt.Sprintf(apisixRouteSpec, s.Namespace(), s.Namespace(), "/headers"))
 				Eventually(request).WithArguments("/get").WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusNotFound))
-				s.NewAPISIXClient().GET("/headers").WithHost("httpbin").Expect().Status(http.StatusOK)
+				Eventually(request).WithArguments("/headers").WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
 
 				By("delete ApisixRoute")
 				err := s.DeleteResource("ApisixRoute", "default")
@@ -1448,9 +1448,14 @@ spec:
 				Path:   "/echo",
 			}
 			headers := http.Header{"Host": []string{"httpbin.org"}}
-			_, resp, _ := websocket.DefaultDialer.Dial(u.String(), headers)
-			// should receive 200 instead of 101
-			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			// In standalone mode, config application is async — retry until the route is active
+			Eventually(func() int {
+				_, resp, _ := websocket.DefaultDialer.Dial(u.String(), headers)
+				if resp == nil {
+					return 0
+				}
+				return resp.StatusCode
+			}).WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
 			By("apply ApisixRoute for WebSocket")
 			var apisixRoute apiv2.ApisixRoute
 			applier.MustApplyAPIv2(


### PR DESCRIPTION
## Problem

The translator sets `hosts` on both Route and Service when translating ApisixRoute resources. For backends that don't support route-level hosts (where hosts is a service-level concept), this causes a false diff every sync cycle: the local state has `route.hosts` but the remote state never does, triggering unnecessary PUT requests.

In production, this leads to massive audit log growth — one customer accumulated 8 GB / 4.2M records of redundant `UpdateService` entries.

## Root Cause

In `buildRoute()` (`internal/adc/translator/apisixroute.go`), `route.Hosts` was set to `rule.Match.Hosts`. However, `buildService()` already sets `service.Hosts` to the same value. Since routes inherit hosts from their parent service, the route-level hosts is redundant and can cause false diffs during config sync.

## Fix

Remove `route.Hosts = rule.Match.Hosts` from `buildRoute()`. `service.Hosts` remains as the canonical location for host matching.

## CI Fix

Also fixes ADC binary extraction in CI workflows: the `ghcr.io/api7/adc:dev` Docker image now bundles `main.cjs` instead of `main.js` at the container root. Updated `e2e-test.yml`, `e2e-test-k8s.yml`, and `apisix-e2e-test.yml`.

## Testing

Added unit tests:
- `TestBuildRoute_HostsNotSet`: verifies route.Hosts is not set after buildRoute
- `TestBuildService_HostsSet`: verifies service.Hosts is correctly set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route translation no longer assigns host matching to individual routes; hosts are applied at the service level.

* **Tests**
  * Added unit tests to validate host-vs-service host matching behavior.
  * Updated end-to-end tests to use retried assertions for HTTP and WebSocket checks to improve stability.

* **Chores**
  * CI workflows updated to extract a CommonJS artifact variant when using the development ADC build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->