### PR TITLE
chore: migrate image registry from hkccr to ghcr.io

### DIFF
--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -63,12 +63,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Login to Private Registry
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: hkccr.ccs.tencentyun.com
-          username: ${{ secrets.PRIVATE_DOCKER_USERNAME }}
-          password: ${{ secrets.PRIVATE_DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build images
         env:

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -36,7 +36,6 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: read
     steps:
       - name: Checkout

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -35,6 +35,9 @@ jobs:
       CONFORMANCE_TEST_REPORT_OUTPUT: /tmp/api7-ingress-controller-conformance-report.yaml
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,13 +58,6 @@ jobs:
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
           chmod 700 get_helm.sh
           ./get_helm.sh
-
-      - name: Login to Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -58,12 +58,12 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
-      - name: Login to Private Registry
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: hkccr.ccs.tencentyun.com
-          username: ${{ secrets.PRIVATE_DOCKER_USERNAME }}
-          password: ${{ secrets.PRIVATE_DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Launch Kind Cluster
         env:

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -38,6 +38,9 @@ jobs:
         cases_subset:
         - v2
     runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -72,12 +72,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Login to Private Registry
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: hkccr.ccs.tencentyun.com
-          username: ${{ secrets.PRIVATE_DOCKER_USERNAME }}
-          password: ${{ secrets.PRIVATE_DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build images
         env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,6 +41,9 @@ jobs:
         - webhook
       fail-fast: false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,13 +67,6 @@ jobs:
 
       - name: Install ginkgo
         run: make install-ginkgo
-
-      - name: Login to Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.DOCKER_REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/Makefile
+++ b/Makefile
@@ -202,9 +202,9 @@ kind-down:
 
 .PHONY: kind-load-images
 kind-load-images: pull-infra-images kind-load-ingress-image kind-load-adc-image
-	@kind load docker-image hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-gateway:dev --name $(KIND_NAME)
-	@kind load docker-image hkccr.ccs.tencentyun.com/api7-dev/api7-ee-dp-manager:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
-	@kind load docker-image hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-integrated:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
+	@kind load docker-image ghcr.io/api7/api7-ee-3-gateway:dev --name $(KIND_NAME)
+	@kind load docker-image ghcr.io/api7/api7-ee-dp-manager:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
+	@kind load docker-image ghcr.io/api7/api7-ee-3-integrated:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
 	@kind load docker-image kennethreitz/httpbin:latest --name $(KIND_NAME)
 	@kind load docker-image jmalloc/echo-server:latest --name $(KIND_NAME)
 	@kind load docker-image apache/apisix:dev --name $(KIND_NAME)
@@ -212,12 +212,12 @@ kind-load-images: pull-infra-images kind-load-ingress-image kind-load-adc-image
 
 .PHONY: kind-load-gateway-image
 kind-load-gateway-image:
-	@kind load docker-image hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-gateway:dev --name $(KIND_NAME)
+	@kind load docker-image ghcr.io/api7/api7-ee-3-gateway:dev --name $(KIND_NAME)
 
 .PHONY: kind-load-dashboard-images
 kind-load-dashboard-images:
-	@kind load docker-image hkccr.ccs.tencentyun.com/api7-dev/api7-ee-dp-manager:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
-	@kind load docker-image hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-integrated:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
+	@kind load docker-image ghcr.io/api7/api7-ee-dp-manager:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
+	@kind load docker-image ghcr.io/api7/api7-ee-3-integrated:$(DASHBOARD_VERSION)  --name $(KIND_NAME)
 
 .PHONY: kind-load-ingress-image
 kind-load-ingress-image:
@@ -231,9 +231,9 @@ kind-load-adc-image:
 
 .PHONY: pull-infra-images
 pull-infra-images:
-	@docker pull hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-gateway:dev
-	@docker pull hkccr.ccs.tencentyun.com/api7-dev/api7-ee-dp-manager:$(DASHBOARD_VERSION)
-	@docker pull hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-integrated:$(DASHBOARD_VERSION)
+	@docker pull ghcr.io/api7/api7-ee-3-gateway:dev
+	@docker pull ghcr.io/api7/api7-ee-dp-manager:$(DASHBOARD_VERSION)
+	@docker pull ghcr.io/api7/api7-ee-3-integrated:$(DASHBOARD_VERSION)
 	@docker pull kennethreitz/httpbin:latest
 	@docker pull jmalloc/echo-server:latest
 	@docker pull ghcr.io/api7/adc:dev

--- a/test/e2e/framework/api7_dashboard.go
+++ b/test/e2e/framework/api7_dashboard.go
@@ -45,7 +45,7 @@ func init() {
 	tmpl, err := template.New("values.yaml").Parse(`
 dashboard:
   image:
-    repository: hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-integrated
+    repository: ghcr.io/api7/api7-ee-3-integrated
     pullPolicy: IfNotPresent
     tag: {{ .Tag }}
   extraEnvVars:
@@ -61,7 +61,7 @@ dashboard:
       mountPath: /app/covdatafiles
 dp_manager:
   image:
-    repository: hkccr.ccs.tencentyun.com/api7-dev/api7-ee-dp-manager
+    repository: ghcr.io/api7/api7-ee-dp-manager
     pullPolicy: IfNotPresent
     tag: {{ .Tag }}
   extraEnvVars:

--- a/test/e2e/framework/manifests/dp.yaml
+++ b/test/e2e/framework/manifests/dp.yaml
@@ -181,7 +181,7 @@ spec:
     spec:
       #serviceAccountName: ginkgo
       containers:
-      - image: hkccr.ccs.tencentyun.com/api7-dev/api7-ee-3-gateway:dev
+      - image: ghcr.io/api7/api7-ee-3-gateway:dev
         imagePullPolicy: IfNotPresent
         env:
     {{- if not .TLSEnabled }}


### PR DESCRIPTION
## Summary

Replace `hkccr.ccs.tencentyun.com/api7-dev/` with `ghcr.io/api7/` across all relevant files.

## Changes

- **Workflow files** (`e2e-test.yml`, `conformance-test.yml`, `e2e-test-k8s.yml`): Replace "Login to Private Registry" step with "Login to GHCR" using `GITHUB_TOKEN`
- **Makefile**: Update all image references in `pull-infra-images`, `kind-load-images`, `kind-load-dashboard-images`, `kind-load-gateway-image` targets
- **`test/e2e/framework/api7_dashboard.go`**: Update Helm values template image repositories
- **`test/e2e/framework/manifests/dp.yaml`**: Update gateway container image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI and build image sources to GitHub Container Registry (ghcr.io) and consolidated registry authentication to use the repository token.
* **Tests**
  * Updated end-to-end test tooling, manifests, and local cluster image loading to pull GHCR-hosted images for test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->