### PR TITLE
fix(backport #2745): exclude status-only API v2 resources from readiness gating

### DIFF
--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -308,16 +308,13 @@ func registerV2ForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessM
 		icgv = netv1beta1.SchemeGroupVersion
 	}
 
-	gvks := []schema.GroupVersionKind{
-		types.GvkOf(&apiv2.ApisixRoute{}),
-		types.GvkOf(&apiv2.ApisixGlobalRule{}),
-		types.GvkOf(&apiv2.ApisixPluginConfig{}),
-		types.GvkOf(&apiv2.ApisixTls{}),
-		types.GvkOf(&apiv2.ApisixConsumer{}),
-		types.GvkOf(&apiv2.ApisixUpstream{}),
-	}
-	if utils.HasAPIResource(mgr, &netv1.Ingress{}) {
-		gvks = append(gvks, types.GvkOf(&netv1.Ingress{}))
+	resources := v2ReadinessResources()
+	gvks := make([]schema.GroupVersionKind, 0, len(resources))
+	for _, resource := range resources {
+		if _, ok := resource.(*netv1.Ingress); ok && !utils.HasAPIResource(mgr, resource) {
+			continue
+		}
+		gvks = append(gvks, types.GvkOf(resource))
 	}
 
 	c := mgr.GetClient()
@@ -330,6 +327,16 @@ func registerV2ForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessM
 		}),
 	})
 	log.Info("Registered v2 GVKs for readiness checks", "gvks", gvks)
+}
+
+func v2ReadinessResources() []client.Object {
+	return []client.Object{
+		&netv1.Ingress{},
+		&apiv2.ApisixRoute{},
+		&apiv2.ApisixGlobalRule{},
+		&apiv2.ApisixTls{},
+		&apiv2.ApisixConsumer{},
+	}
 }
 
 func registerGatewayAPIForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager, log logr.Logger) {

--- a/internal/manager/controllers_test.go
+++ b/internal/manager/controllers_test.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package manager
+
+import (
+	"testing"
+
+	netv1 "k8s.io/api/networking/v1"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+	types "github.com/apache/apisix-ingress-controller/internal/types"
+)
+
+func TestV2ReadinessResources(t *testing.T) {
+	resources := v2ReadinessResources()
+	seen := make(map[string]bool, len(resources))
+	for _, resource := range resources {
+		seen[types.GvkOf(resource).String()] = true
+	}
+
+	want := []string{
+		types.GvkOf(&netv1.Ingress{}).String(),
+		types.GvkOf(&apiv2.ApisixRoute{}).String(),
+		types.GvkOf(&apiv2.ApisixGlobalRule{}).String(),
+		types.GvkOf(&apiv2.ApisixTls{}).String(),
+		types.GvkOf(&apiv2.ApisixConsumer{}).String(),
+	}
+	for _, gvk := range want {
+		if !seen[gvk] {
+			t.Fatalf("expected readiness resources to include %s", gvk)
+		}
+	}
+
+	notExpected := []string{
+		types.GvkOf(&apiv2.ApisixPluginConfig{}).String(),
+		types.GvkOf(&apiv2.ApisixUpstream{}).String(),
+	}
+	for _, gvk := range notExpected {
+		if seen[gvk] {
+			t.Fatalf("expected readiness resources to exclude %s", gvk)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- exclude `ApisixPluginConfig` and `ApisixUpstream` from API v2 startup readiness gating
- keep readiness registration limited to resources that actually drive startup sync progression
- add a unit test to lock the readiness resource list and prevent regressions

## Why
`ApisixPluginConfig` and `ApisixUpstream` are status-oriented resources in this branch and do not call `Readier.Done(...)` themselves. Keeping them in the startup readiness set can block the provider's first sync until the readiness timeout expires. Removing them from readiness gating avoids that unnecessary startup delay while preserving readiness coverage for the resources that already participate in the startup lifecycle.

## Testing
- `go test $(go list ./... | grep -v /e2e | grep -v /conformance)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated readiness monitoring to track Ingress, ApisixRoute, ApisixGlobalRule, ApisixTls, and ApisixConsumer resources; removed monitoring for ApisixPluginConfig and ApisixUpstream.
  * Enhanced resource availability detection to conditionally handle Ingress resources based on cluster configuration.
* **Tests**
  * Added test coverage for readiness resource monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->