### PR TITLE
fix: omit uris field when HTTPRoute path type is RegularExpression (backport apache/apisix-ingress-controller#2770)

### DIFF
--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -741,6 +741,10 @@ func (t *Translator) translateGatewayHTTPRouteMatch(match *gatewayv1.HTTPRouteMa
 			})
 
 			route.Vars = append(route.Vars, this)
+			// APISIX Admin API requires uris to be a non-null array. Use "/*"
+			// as a catch-all so APISIX accepts the route; the vars entry above
+			// performs the actual regex filtering.
+			route.Uris = []string{"/*"}
 		default:
 			return nil, errors.New("unknown path match type " + string(*match.Path.Type))
 		}

--- a/test/e2e/gatewayapi/httproute.go
+++ b/test/e2e/gatewayapi/httproute.go
@@ -942,6 +942,60 @@ spec:
 			})
 		})
 
+		It("HTTPRoute RegularExpression Match", func() {
+			var regexRoute = fmt.Sprintf(`
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+spec:
+  parentRefs:
+  - name: %s
+  hostnames:
+  - httpbin.example
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: /status/[0-9]+
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 80
+`, s.Namespace())
+
+			By("create HTTPRoute with RegularExpression path type")
+			s.ResourceApplied("HTTPRoute", "httpbin", regexRoute, 1)
+
+			By("access dataplane: path matching regex should succeed")
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:   "GET",
+				Path:     "/status/200",
+				Host:     "httpbin.example",
+				Check:    scaffold.WithExpectedStatus(http.StatusOK),
+				Timeout:  time.Second * 30,
+				Interval: time.Second * 2,
+			})
+
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:   "GET",
+				Path:     "/status/201",
+				Host:     "httpbin.example",
+				Check:    scaffold.WithExpectedStatus(http.StatusCreated),
+				Timeout:  time.Second * 30,
+				Interval: time.Second * 2,
+			})
+
+			By("access dataplane: path not matching regex should return 404")
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:   "GET",
+				Path:     "/status/ok",
+				Host:     "httpbin.example",
+				Check:    scaffold.WithExpectedStatus(http.StatusNotFound),
+				Timeout:  time.Second * 30,
+				Interval: time.Second * 2,
+			})
+		})
+
 		It("HTTPRoute Method Match", func() {
 			By("create HTTPRoute")
 			s.ResourceApplied("HTTPRoute", "httpbin", fmt.Sprintf(methodRouteGETAndDELETEByAnything, s.Namespace()), 1)


### PR DESCRIPTION
## Problem

When an `HTTPRoute` uses `path.type: RegularExpression`, the controller correctly generates a `vars` entry for regex matching, but never sets `uris` — leaving it `nil`. Without `omitempty`, `nil` serializes as `"uris": null`, which is rejected by the APISIX Admin API v3 with HTTP 400:

```
{"errors":[{"expected":"array","code":"invalid_type","path":["services",0,"routes",0,"uris"],"message":"Invalid input: expected array, received null"}]}
```

Because the controller sends all services in a single bulk payload, **every route in the cluster fails to sync** — not just the offending regex route.

> Note: simply adding `omitempty` to the `Uris` field also fails — APISIX rejects an absent field the same way (`received undefined`).

## Root Cause

In `translateGatewayHTTPRouteMatch`, the `PathMatchRegularExpression` case only appends to `route.Vars` and never sets `route.Uris`:

```go
// before fix
case gatewayv1.PathMatchRegularExpression:
    // builds vars entry for regex ...
    route.Vars = append(route.Vars, this)
    // route.Uris is never set → nil → serialized as null
```

## Fix

Set `route.Uris = []string{"/*"}` as a catch-all in the `RegularExpression` case. APISIX routing first matches by `uris`, then applies `vars` conditions — so `"/*"` lets every path through, while the `vars` regex does the actual filtering:

```go
// after fix
case gatewayv1.PathMatchRegularExpression:
    // builds vars entry for regex ...
    route.Vars = append(route.Vars, this)
    // "/*" satisfies the Admin API; vars performs the real regex match
    route.Uris = []string{"/*"}
```

The resulting APISIX route payload for a regex path `/lk.*` now looks like:

```json
{
  "uris": ["/*"],
  "vars": [["uri", "~~", "/lk.*"]]
}
```

## Example

Apply an `HTTPRoute` with `RegularExpression` path type:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: httpbin
spec:
  parentRefs:
  - name: my-gateway
  rules:
  - matches:
    - path:
        type: RegularExpression
        value: /status/[0-9]+
    backendRefs:
    - name: httpbin
      port: 80
```

Before the fix: all routes across the cluster fail to sync (HTTP 400).  
After the fix: the route syncs correctly and requests to `/status/200` or `/status/404` are forwarded to the backend, while `/status/ok` (non-numeric) returns 404.

## Changes

- `internal/adc/translator/httproute.go`: set `route.Uris = ["/*"]` in the `PathMatchRegularExpression` case
- `test/e2e/gatewayapi/httproute.go`: add `HTTPRoute RegularExpression Match` e2e test
