### PR TITLE
fix: update observedGeneration on Gateway-API route status conditions (apache/apisix-ingress-controller#2768)

### DIFF
--- a/internal/provider/api7ee/status.go
+++ b/internal/provider/api7ee/status.go
@@ -122,6 +122,7 @@ func (d *api7eeProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1.HTTPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1.HTTPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -157,6 +158,7 @@ func (d *api7eeProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1alpha2.UDPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1alpha2.UDPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -192,6 +194,7 @@ func (d *api7eeProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1alpha2.TCPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1alpha2.TCPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -227,6 +230,7 @@ func (d *api7eeProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1.GRPCRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1.GRPCRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs

--- a/internal/provider/apisix/status.go
+++ b/internal/provider/apisix/status.go
@@ -123,6 +123,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1.HTTPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1.HTTPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -158,6 +159,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1alpha2.UDPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1alpha2.UDPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -193,6 +195,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1alpha2.TCPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1alpha2.TCPRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs
@@ -228,6 +231,7 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 			Resource:       &gatewayv1.GRPCRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
 				cp := obj.(*gatewayv1.GRPCRoute).DeepCopy()
+				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
 					ns := gatewayNs

--- a/test/e2e/gatewayapi/status.go
+++ b/test/e2e/gatewayapi/status.go
@@ -173,6 +173,7 @@ spec:
 					And(
 						ContainSubstring(`status: "True"`),
 						ContainSubstring(`reason: Accepted`),
+						ContainSubstring(`observedGeneration: 1`),
 					),
 				)
 


### PR DESCRIPTION
Stamps `condition.ObservedGeneration = cp.GetGeneration()` inside the four Gateway-API mutator closures (`HTTPRoute`, `UDPRoute`, `TCPRoute`, `GRPCRoute`) before `MergeCondition`, mirroring what `SetApisixCRDConditionWithGeneration` already does for the legacy CRDs.

**Before** (HTTPRoute after a sync failure→recovery cycle):

```yaml
metadata:
  generation: 1
status:
  parents:
  - conditions:
    - type: Accepted
      status: "True"
      observedGeneration: 0   # mismatched
```

**After:**

```yaml
metadata:
  generation: 1
status:
  parents:
  - conditions:
    - type: Accepted
      status: "True"
      observedGeneration: 1   # matches metadata.generation
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected route status reporting so the observedGeneration is now populated for Gateway API route statuses (HTTP, UDP, TCP, GRPC), improving accuracy of change tracking.

* **Tests**
  * Updated end-to-end checks to assert observedGeneration in route status after scaling events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/api7-ingress-controller/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->