### PR TITLE
fix: honor BackendTrafficPolicy targetRefs.sectionName for Service ports

### DIFF
--- a/internal/adc/translator/grpcroute.go
+++ b/internal/adc/translator/grpcroute.go
@@ -192,7 +192,7 @@ func (t *Translator) TranslateGRPCRoute(tctx *provider.TranslateContext, grpcRou
 				continue
 			}
 
-			t.AttachBackendTrafficPolicyToUpstream(backend.BackendRef, tctx.BackendTrafficPolicies, upstream)
+			t.AttachBackendTrafficPolicyToUpstream(backend.BackendRef, tctx.BackendTrafficPolicies, upstream, tctx.Services)
 			upstream.Nodes = upNodes
 
 			var (

--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -570,7 +570,7 @@ func (t *Translator) TranslateHTTPRoute(tctx *provider.TranslateContext, httpRou
 				enableWebsocket = ptr.To(true)
 			}
 
-			t.AttachBackendTrafficPolicyToUpstream(backend.BackendRef, tctx.BackendTrafficPolicies, upstream)
+			t.AttachBackendTrafficPolicyToUpstream(backend.BackendRef, tctx.BackendTrafficPolicies, upstream, tctx.Services)
 			upstream.Nodes = upNodes
 			if upstream.Scheme == "" {
 				upstream.Scheme = appProtocolToUpstreamScheme(protocol)

--- a/internal/adc/translator/httproute_test.go
+++ b/internal/adc/translator/httproute_test.go
@@ -309,3 +309,106 @@ func TestAttachBackendTrafficPolicyHealthCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestAttachBackendTrafficPolicyToUpstreamSectionName(t *testing.T) {
+	const (
+		namespace   = "default"
+		serviceName = "backend"
+		webPort     = int32(80)
+		webName     = "web"
+		adminPort   = int32(9000)
+		adminName   = "admin"
+	)
+
+	serviceKey := types.NamespacedName{Namespace: namespace, Name: serviceName}
+	services := map[types.NamespacedName]*corev1.Service{
+		serviceKey: {
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Name: webName, Port: webPort},
+					{Name: adminName, Port: adminPort},
+				},
+			},
+		},
+	}
+
+	newRef := func(port int32) gatewayv1.BackendRef {
+		return gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name:      gatewayv1.ObjectName(serviceName),
+				Namespace: ptr.To(gatewayv1.Namespace(namespace)),
+				Port:      ptr.To(gatewayv1.PortNumber(port)),
+			},
+		}
+	}
+
+	newPolicy := func(name, sectionName, scheme string) *v1alpha1.BackendTrafficPolicy {
+		targetRef := v1alpha1.BackendPolicyTargetReferenceWithSectionName{
+			LocalPolicyTargetReference: gatewayv1alpha2.LocalPolicyTargetReference{
+				Name: gatewayv1alpha2.ObjectName(serviceName),
+				Kind: gatewayv1alpha2.Kind(internaltypes.KindService),
+			},
+		}
+		if sectionName != "" {
+			targetRef.SectionName = ptr.To(gatewayv1alpha2.SectionName(sectionName))
+		}
+		return &v1alpha1.BackendTrafficPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: v1alpha1.BackendTrafficPolicySpec{
+				TargetRefs: []v1alpha1.BackendPolicyTargetReferenceWithSectionName{targetRef},
+				Scheme:     scheme,
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		ref        gatewayv1.BackendRef
+		policies   map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy
+		wantScheme string
+	}{
+		{
+			name: "sectionName matches the backend port name",
+			ref:  newRef(webPort),
+			policies: map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy{
+				{Namespace: namespace, Name: "p"}: newPolicy("p", webName, apiv2.SchemeHTTPS),
+			},
+			wantScheme: apiv2.SchemeHTTPS,
+		},
+		{
+			name: "sectionName does not match the backend port name",
+			ref:  newRef(adminPort),
+			policies: map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy{
+				{Namespace: namespace, Name: "p"}: newPolicy("p", webName, apiv2.SchemeHTTPS),
+			},
+			wantScheme: "",
+		},
+		{
+			name: "no sectionName applies to the whole service",
+			ref:  newRef(adminPort),
+			policies: map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy{
+				{Namespace: namespace, Name: "p"}: newPolicy("p", "", apiv2.SchemeHTTPS),
+			},
+			wantScheme: apiv2.SchemeHTTPS,
+		},
+		{
+			name: "port-specific policy takes precedence over whole-service policy",
+			ref:  newRef(adminPort),
+			policies: map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy{
+				{Namespace: namespace, Name: "generic"}:  newPolicy("generic", "", apiv2.SchemeHTTP),
+				{Namespace: namespace, Name: "specific"}: newPolicy("specific", adminName, apiv2.SchemeHTTPS),
+			},
+			wantScheme: apiv2.SchemeHTTPS,
+		},
+	}
+
+	translator := NewTranslator(logr.Discard())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := adctypes.NewDefaultUpstream()
+			translator.AttachBackendTrafficPolicyToUpstream(tt.ref, tt.policies, upstream, services)
+			assert.Equal(t, tt.wantScheme, upstream.Scheme)
+		})
+	}
+}

--- a/internal/adc/translator/httproute_test.go
+++ b/internal/adc/translator/httproute_test.go
@@ -401,6 +401,25 @@ func TestAttachBackendTrafficPolicyToUpstreamSectionName(t *testing.T) {
 			},
 			wantScheme: apiv2.SchemeHTTPS,
 		},
+		{
+			name: "targetRef kind mismatch does not attach to a same-named service",
+			ref:  newRef(webPort),
+			policies: map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy{
+				{Namespace: namespace, Name: "p"}: {
+					ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: namespace},
+					Spec: v1alpha1.BackendTrafficPolicySpec{
+						TargetRefs: []v1alpha1.BackendPolicyTargetReferenceWithSectionName{{
+							LocalPolicyTargetReference: gatewayv1alpha2.LocalPolicyTargetReference{
+								Name: gatewayv1alpha2.ObjectName(serviceName),
+								Kind: gatewayv1alpha2.Kind("ServiceImport"),
+							},
+						}},
+						Scheme: apiv2.SchemeHTTPS,
+					},
+				},
+			},
+			wantScheme: "",
+		},
 	}
 
 	translator := NewTranslator(logr.Discard())

--- a/internal/adc/translator/ingress.go
+++ b/internal/adc/translator/ingress.go
@@ -187,7 +187,7 @@ func (t *Translator) resolveIngressUpstream(
 		ns = config.ServiceNamespace
 	}
 	backendRef := convertBackendRef(ns, backendService.Name, internaltypes.KindService)
-	t.AttachBackendTrafficPolicyToUpstream(backendRef, tctx.BackendTrafficPolicies, upstream)
+	t.AttachBackendTrafficPolicyToUpstream(backendRef, tctx.BackendTrafficPolicies, upstream, tctx.Services)
 	if config != nil {
 		upConfig := config.Upstream
 		if upConfig.Scheme != "" {

--- a/internal/adc/translator/policies.go
+++ b/internal/adc/translator/policies.go
@@ -29,6 +29,7 @@ import (
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 )
 
 func convertBackendRef(namespace, name, kind string) gatewayv1.BackendRef {
@@ -43,6 +44,17 @@ func (t *Translator) AttachBackendTrafficPolicyToUpstream(ref gatewayv1.BackendR
 	if len(policies) == 0 {
 		return
 	}
+	// Resolve the backend ref group/kind, applying the Gateway API defaults
+	// (empty group = core, Service kind) so a targetRef is only matched against
+	// a backend of the same resource type.
+	refGroup := ""
+	if ref.Group != nil {
+		refGroup = string(*ref.Group)
+	}
+	refKind := internaltypes.KindService
+	if ref.Kind != nil {
+		refKind = string(*ref.Kind)
+	}
 	// A targetRef with sectionName scopes the policy to a specific Service port
 	// (matched by port name). It takes precedence over a whole-Service targetRef
 	// (no sectionName) that matches the same backend.
@@ -53,6 +65,12 @@ func (t *Translator) AttachBackendTrafficPolicyToUpstream(ref gatewayv1.BackendR
 		}
 		for _, targetRef := range po.Spec.TargetRefs {
 			if ref.Name != targetRef.Name {
+				continue
+			}
+			if targetRef.Group != "" && string(targetRef.Group) != refGroup {
+				continue
+			}
+			if targetRef.Kind != "" && string(targetRef.Kind) != refKind {
 				continue
 			}
 			if targetRef.SectionName != nil && *targetRef.SectionName != "" {

--- a/internal/adc/translator/policies.go
+++ b/internal/adc/translator/policies.go
@@ -20,6 +20,7 @@ package translator
 import (
 	"encoding/json"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -38,26 +39,58 @@ func convertBackendRef(namespace, name, kind string) gatewayv1.BackendRef {
 	return backendRef
 }
 
-func (t *Translator) AttachBackendTrafficPolicyToUpstream(ref gatewayv1.BackendRef, policies map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy, upstream *adctypes.Upstream) {
+func (t *Translator) AttachBackendTrafficPolicyToUpstream(ref gatewayv1.BackendRef, policies map[types.NamespacedName]*v1alpha1.BackendTrafficPolicy, upstream *adctypes.Upstream, services map[types.NamespacedName]*corev1.Service) {
 	if len(policies) == 0 {
 		return
 	}
-	var policy *v1alpha1.BackendTrafficPolicy
+	// A targetRef with sectionName scopes the policy to a specific Service port
+	// (matched by port name). It takes precedence over a whole-Service targetRef
+	// (no sectionName) that matches the same backend.
+	var genericPolicy, specificPolicy *v1alpha1.BackendTrafficPolicy
 	for _, po := range policies {
 		if ref.Namespace != nil && string(*ref.Namespace) != po.Namespace {
 			continue
 		}
 		for _, targetRef := range po.Spec.TargetRefs {
-			if ref.Name == targetRef.Name {
-				policy = po
-				break
+			if ref.Name != targetRef.Name {
+				continue
 			}
+			if targetRef.SectionName != nil && *targetRef.SectionName != "" {
+				if backendRefMatchesSectionName(ref, po.Namespace, string(*targetRef.SectionName), services) {
+					specificPolicy = po
+				}
+				continue
+			}
+			genericPolicy = po
 		}
+	}
+	policy := specificPolicy
+	if policy == nil {
+		policy = genericPolicy
 	}
 	if policy == nil {
 		return
 	}
 	t.attachBackendTrafficPolicyToUpstream(policy, upstream)
+}
+
+// backendRefMatchesSectionName reports whether the backend ref resolves to the
+// Service port named sectionName. Per the Gateway API policy semantics, when a
+// sectionName is specified but cannot be resolved, the policy must not attach.
+func backendRefMatchesSectionName(ref gatewayv1.BackendRef, namespace, sectionName string, services map[types.NamespacedName]*corev1.Service) bool {
+	if ref.Port == nil {
+		return false
+	}
+	svc, ok := services[types.NamespacedName{Namespace: namespace, Name: string(ref.Name)}]
+	if !ok || svc == nil {
+		return false
+	}
+	for _, port := range svc.Spec.Ports {
+		if port.Port == int32(*ref.Port) {
+			return port.Name == sectionName
+		}
+	}
+	return false
 }
 
 func (t *Translator) attachBackendTrafficPolicyToUpstream(policy *v1alpha1.BackendTrafficPolicy, upstream *adctypes.Upstream) {

--- a/internal/adc/translator/tcproute.go
+++ b/internal/adc/translator/tcproute.go
@@ -69,7 +69,7 @@ func (t *Translator) TranslateTCPRoute(tctx *provider.TranslateContext, tcpRoute
 				continue
 			}
 			// TODO: Confirm BackendTrafficPolicy attachment with e2e test case.
-			t.AttachBackendTrafficPolicyToUpstream(backend, tctx.BackendTrafficPolicies, upstream)
+			t.AttachBackendTrafficPolicyToUpstream(backend, tctx.BackendTrafficPolicies, upstream, tctx.Services)
 			upstream.Nodes = upNodes
 			var (
 				kind string

--- a/internal/adc/translator/tlsroute.go
+++ b/internal/adc/translator/tlsroute.go
@@ -62,7 +62,7 @@ func (t *Translator) TranslateTLSRoute(tctx *provider.TranslateContext, tlsRoute
 				continue
 			}
 			// TODO: Confirm BackendTrafficPolicy attachment with e2e test case.
-			t.AttachBackendTrafficPolicyToUpstream(backend, tctx.BackendTrafficPolicies, upstream)
+			t.AttachBackendTrafficPolicyToUpstream(backend, tctx.BackendTrafficPolicies, upstream, tctx.Services)
 			upstream.Nodes = upNodes
 			var (
 				kind string

--- a/internal/adc/translator/udproute.go
+++ b/internal/adc/translator/udproute.go
@@ -58,7 +58,7 @@ func (t *Translator) TranslateUDPRoute(tctx *provider.TranslateContext, udpRoute
 				continue
 			}
 			// TODO: Confirm BackendTrafficPolicy attachment with e2e test case.
-			t.AttachBackendTrafficPolicyToUpstream(backend, tctx.BackendTrafficPolicies, upstream)
+			t.AttachBackendTrafficPolicyToUpstream(backend, tctx.BackendTrafficPolicies, upstream, tctx.Services)
 			upstream.Nodes = upNodes
 			var (
 				kind string

--- a/internal/controller/policies.go
+++ b/internal/controller/policies.go
@@ -47,10 +47,14 @@ import (
 type PolicyTargetKey struct {
 	NsName    types.NamespacedName
 	GroupKind schema.GroupKind
+	// SectionName scopes the target to a specific section (for a Service, the
+	// port name). Policies that target different sections of the same resource
+	// do not conflict; an empty SectionName targets the whole resource.
+	SectionName string
 }
 
 func (p PolicyTargetKey) String() string {
-	return p.NsName.String() + "/" + p.GroupKind.String()
+	return p.NsName.String() + "/" + p.GroupKind.String() + "/" + p.SectionName
 }
 
 func BackendTrafficPolicyPredicateFunc(channel chan event.GenericEvent) predicate.Predicate {
@@ -142,6 +146,9 @@ func ProcessBackendTrafficPolicy(
 			key := PolicyTargetKey{
 				NsName:    types.NamespacedName{Namespace: p.GetNamespace(), Name: string(targetRef.Name)},
 				GroupKind: schema.GroupKind{Group: "", Kind: internaltypes.KindService},
+			}
+			if sectionName != nil {
+				key.SectionName = string(*sectionName)
 			}
 			condition := NewPolicyCondition(policy.Generation, true, "Policy has been accepted")
 			if sectionName != nil && !servicePortNameMap[fmt.Sprintf("%s/%s/%s", policy.Namespace, string(targetRef.Name), *sectionName)] {

--- a/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
+++ b/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
@@ -162,20 +162,28 @@ spec:
 
 	Context("Section Name", func() {
 		// httpbin-service-e2e-test exposes two named ports backed by the same pod:
-		// "http" (80) and "http-v2" (8080). Routing one host to each port lets us
-		// assert that a sectionName-scoped policy only attaches to the matching port.
-		var routeToHTTPV2Port = `
+		// "http" (80) and "http-v2" (8080). A single HTTPRoute routes /get to port
+		// 80 and /headers to port 8080, so the two rules share the same Service but
+		// resolve to different ports.
+		var routeWithTwoPorts = `
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: httpbin-v2
+  name: httpbin
   namespace: %s
 spec:
   parentRefs:
   - name: %s
   hostnames:
-  - "httpbin-v2.org"
+  - "httpbin.org"
   rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /get
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 80
   - matches:
     - path:
         type: Exact
@@ -185,95 +193,74 @@ spec:
       port: 8080
 `
 
-		var policyTmpl = `
+		// sectionPolicy is scoped to the http-v2 (8080) port via sectionName.
+		var sectionPolicy = `
 apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
-  name: httpbin
+  name: httpbin-section
 spec:
   targetRefs:
   - name: httpbin-service-e2e-test
     kind: Service
     group: ""
-    sectionName: %s
+    sectionName: http-v2
   passHost: rewrite
-  upstreamHost: %s
+  upstreamHost: section.http-v2.example.com
+`
+
+		// wholePolicy has no sectionName, so it targets the whole Service.
+		var wholePolicy = `
+apiVersion: apisix.apache.org/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: httpbin-whole
+spec:
+  targetRefs:
+  - name: httpbin-service-e2e-test
+    kind: Service
+    group: ""
+  passHost: rewrite
+  upstreamHost: whole.service.example.com
 `
 
 		BeforeEach(func() {
 			gatewayBeforeEach()
-			By("create HTTPRoute routing to the http-v2 (8080) port")
-			s.ApplyHTTPRoute(types.NamespacedName{Namespace: s.Namespace(), Name: "httpbin-v2"}, fmt.Sprintf(routeToHTTPV2Port, s.Namespace(), s.Namespace()))
+			By("recreate the HTTPRoute with two rules to ports 80 and 8080")
+			s.ApplyHTTPRoute(types.NamespacedName{Namespace: s.Namespace(), Name: "httpbin"}, fmt.Sprintf(routeWithTwoPorts, s.Namespace(), s.Namespace()))
 		})
 
-		// assertScopedToPort applies a policy targeting the given port name and
-		// asserts it attaches to exactly that port: the host routed to the matched
-		// port gets the rewritten upstreamHost, while the host routed to the other
-		// port keeps the original host. matchedHost routes to the port named by
-		// sectionName; otherHost routes to the other port.
-		assertScopedToPort := func(sectionName, rewriteHost, matchedHost, otherHost string) {
-			s.ResourceApplied("BackendTrafficPolicy", "httpbin", fmt.Sprintf(policyTmpl, sectionName, rewriteHost), 1)
+		It("applies the sectionName-scoped policy only to the matching port", func() {
+			s.ResourceApplied("BackendTrafficPolicy", "httpbin-section", sectionPolicy, 1)
+			s.ResourceApplied("BackendTrafficPolicy", "httpbin-whole", wholePolicy, 1)
 
-			// Drive traffic to both hosts so both per-port upstreams are registered.
-			for _, host := range []string{matchedHost, otherHost} {
-				s.RequestAssert(&scaffold.RequestAssert{
-					Method:  "GET",
-					Path:    "/headers",
-					Host:    host,
-					Headers: map[string]string{"Host": host},
-					Checks:  []scaffold.ResponseCheckFunc{scaffold.WithExpectedStatus(200)},
-				})
-			}
-
-			// The Service is split into two per-port upstreams (http/80 and
-			// http-v2/8080) with identical nodes. The sectionName-scoped policy must
-			// attach to exactly one of them; under name-only matching it would attach
-			// to both (the whole Service), which this assertion rejects.
-			Eventually(func(g Gomega) {
-				ups, err := s.DefaultDataplaneResource().Upstream().List(context.Background())
-				g.Expect(err).ToNot(HaveOccurred(), "listing upstreams")
-				g.Expect(ups).To(HaveLen(2), "two per-port upstreams should exist")
-
-				var rewritten []*adctypes.Upstream
-				for _, u := range ups {
-					if u.PassHost == "rewrite" && u.UpstreamHost == rewriteHost {
-						rewritten = append(rewritten, u)
-					}
-				}
-				g.Expect(rewritten).To(HaveLen(1), "policy must attach to exactly the sectionName-matched port, not the whole Service")
-			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
-
-			By("the matched port reflects the rewritten host")
+			// /headers -> port 8080: both policies match by name, but the
+			// sectionName-scoped one wins, so the http-v2 host is used.
+			By("the http-v2 (8080) port uses the sectionName-scoped policy")
 			s.RequestAssert(&scaffold.RequestAssert{
-				Method:  "GET",
-				Path:    "/headers",
-				Host:    matchedHost,
-				Headers: map[string]string{"Host": matchedHost},
+				Method: "GET",
+				Path:   "/headers",
+				Host:   "httpbin.org",
 				Checks: []scaffold.ResponseCheckFunc{
 					scaffold.WithExpectedStatus(200),
-					scaffold.WithExpectedBodyContains(rewriteHost),
+					scaffold.WithExpectedBodyContains("section.http-v2.example.com"),
+					scaffold.WithExpectedBodyNotContains("whole.service.example.com"),
 				},
 			})
 
-			By("the other port keeps the original host")
+			// /get -> port 80: the sectionName-scoped policy does not match this
+			// port, so only the whole-Service policy applies.
+			By("the http (80) port falls back to the whole-Service policy")
 			s.RequestAssert(&scaffold.RequestAssert{
-				Method:  "GET",
-				Path:    "/headers",
-				Host:    otherHost,
-				Headers: map[string]string{"Host": otherHost},
+				Method: "GET",
+				Path:   "/get",
+				Host:   "httpbin.org",
 				Checks: []scaffold.ResponseCheckFunc{
 					scaffold.WithExpectedStatus(200),
-					scaffold.WithExpectedBodyNotContains(rewriteHost),
+					scaffold.WithExpectedBodyContains("whole.service.example.com"),
+					scaffold.WithExpectedBodyNotContains("section.http-v2.example.com"),
 				},
 			})
-		}
-
-		It("attaches the policy to the http-v2 (8080) port when sectionName is http-v2", func() {
-			assertScopedToPort("http-v2", "httpbin.section-v2.example.com", "httpbin-v2.org", "httpbin.org")
-		})
-
-		It("attaches the policy to the http (80) port when sectionName is http", func() {
-			assertScopedToPort("http", "httpbin.section-http.example.com", "httpbin.org", "httpbin-v2.org")
 		})
 	})
 

--- a/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
+++ b/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
@@ -160,6 +160,85 @@ spec:
 		})
 	})
 
+	Context("Section Name", func() {
+		// httpbin-service-e2e-test exposes two named ports backed by the same pod:
+		// "http" (80) and "http-v2" (8080). Routing one host to each port lets us
+		// assert that a sectionName-scoped policy only attaches to the matching port.
+		var routeToHTTPV2Port = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-v2
+  namespace: %s
+spec:
+  parentRefs:
+  - name: %s
+  hostnames:
+  - "httpbin-v2.org"
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /headers
+    backendRefs:
+    - name: httpbin-service-e2e-test
+      port: 8080
+`
+
+		var policyScopedToHTTPV2 = `
+apiVersion: apisix.apache.org/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: httpbin
+spec:
+  targetRefs:
+  - name: httpbin-service-e2e-test
+    kind: Service
+    group: ""
+    sectionName: http-v2
+  passHost: rewrite
+  upstreamHost: httpbin.section-v2.example.com
+`
+
+		BeforeEach(func() {
+			gatewayBeforeEach()
+			By("create HTTPRoute routing to the http-v2 (8080) port")
+			s.ApplyHTTPRoute(types.NamespacedName{Namespace: s.Namespace(), Name: "httpbin-v2"}, fmt.Sprintf(routeToHTTPV2Port, s.Namespace(), s.Namespace()))
+		})
+
+		It("should only attach to the backend matching sectionName", func() {
+			s.ResourceApplied("BackendTrafficPolicy", "httpbin", policyScopedToHTTPV2, 1)
+
+			By("policy applies to the http-v2 (8080) backend")
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/headers",
+				Host:   "httpbin-v2.org",
+				Headers: map[string]string{
+					"Host": "httpbin-v2.org",
+				},
+				Checks: []scaffold.ResponseCheckFunc{
+					scaffold.WithExpectedStatus(200),
+					scaffold.WithExpectedBodyContains("httpbin.section-v2.example.com"),
+				},
+			})
+
+			By("policy does not apply to the http (80) backend")
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method: "GET",
+				Path:   "/headers",
+				Host:   "httpbin.org",
+				Headers: map[string]string{
+					"Host": "httpbin.org",
+				},
+				Checks: []scaffold.ResponseCheckFunc{
+					scaffold.WithExpectedStatus(200),
+					scaffold.WithExpectedBodyNotContains("httpbin.section-v2.example.com"),
+				},
+			})
+		})
+	})
+
 	Context("Health Check", func() {
 		var policyWithActiveHealthCheck = `
 apiVersion: apisix.apache.org/v1alpha1

--- a/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
+++ b/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
@@ -185,7 +185,7 @@ spec:
       port: 8080
 `
 
-		var policyScopedToHTTPV2 = `
+		var policyTmpl = `
 apiVersion: apisix.apache.org/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
@@ -195,9 +195,9 @@ spec:
   - name: httpbin-service-e2e-test
     kind: Service
     group: ""
-    sectionName: http-v2
+    sectionName: %s
   passHost: rewrite
-  upstreamHost: httpbin.section-v2.example.com
+  upstreamHost: %s
 `
 
 		BeforeEach(func() {
@@ -206,27 +206,24 @@ spec:
 			s.ApplyHTTPRoute(types.NamespacedName{Namespace: s.Namespace(), Name: "httpbin-v2"}, fmt.Sprintf(routeToHTTPV2Port, s.Namespace(), s.Namespace()))
 		})
 
-		const rewrittenHost = "httpbin.section-v2.example.com"
+		// assertScopedToPort applies a policy targeting the given port name and
+		// asserts it attaches to exactly that port: the host routed to the matched
+		// port gets the rewritten upstreamHost, while the host routed to the other
+		// port keeps the original host. matchedHost routes to the port named by
+		// sectionName; otherHost routes to the other port.
+		assertScopedToPort := func(sectionName, rewriteHost, matchedHost, otherHost string) {
+			s.ResourceApplied("BackendTrafficPolicy", "httpbin", fmt.Sprintf(policyTmpl, sectionName, rewriteHost), 1)
 
-		It("should only attach to the backend matching sectionName", func() {
-			s.ResourceApplied("BackendTrafficPolicy", "httpbin", policyScopedToHTTPV2, 1)
-
-			// Drive traffic to both hosts so both per-port upstreams are registered
-			// in the dataplane.
-			s.RequestAssert(&scaffold.RequestAssert{
-				Method:  "GET",
-				Path:    "/headers",
-				Host:    "httpbin-v2.org",
-				Headers: map[string]string{"Host": "httpbin-v2.org"},
-				Checks:  []scaffold.ResponseCheckFunc{scaffold.WithExpectedStatus(200)},
-			})
-			s.RequestAssert(&scaffold.RequestAssert{
-				Method:  "GET",
-				Path:    "/headers",
-				Host:    "httpbin.org",
-				Headers: map[string]string{"Host": "httpbin.org"},
-				Checks:  []scaffold.ResponseCheckFunc{scaffold.WithExpectedStatus(200)},
-			})
+			// Drive traffic to both hosts so both per-port upstreams are registered.
+			for _, host := range []string{matchedHost, otherHost} {
+				s.RequestAssert(&scaffold.RequestAssert{
+					Method:  "GET",
+					Path:    "/headers",
+					Host:    host,
+					Headers: map[string]string{"Host": host},
+					Checks:  []scaffold.ResponseCheckFunc{scaffold.WithExpectedStatus(200)},
+				})
+			}
 
 			// The Service is split into two per-port upstreams (http/80 and
 			// http-v2/8080) with identical nodes. The sectionName-scoped policy must
@@ -239,36 +236,44 @@ spec:
 
 				var rewritten []*adctypes.Upstream
 				for _, u := range ups {
-					if u.PassHost == "rewrite" && u.UpstreamHost == rewrittenHost {
+					if u.PassHost == "rewrite" && u.UpstreamHost == rewriteHost {
 						rewritten = append(rewritten, u)
 					}
 				}
 				g.Expect(rewritten).To(HaveLen(1), "policy must attach to exactly the sectionName-matched port, not the whole Service")
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 
-			By("the matched backend (httpbin-v2.org -> 8080) reflects the rewritten host")
+			By("the matched port reflects the rewritten host")
 			s.RequestAssert(&scaffold.RequestAssert{
 				Method:  "GET",
 				Path:    "/headers",
-				Host:    "httpbin-v2.org",
-				Headers: map[string]string{"Host": "httpbin-v2.org"},
+				Host:    matchedHost,
+				Headers: map[string]string{"Host": matchedHost},
 				Checks: []scaffold.ResponseCheckFunc{
 					scaffold.WithExpectedStatus(200),
-					scaffold.WithExpectedBodyContains(rewrittenHost),
+					scaffold.WithExpectedBodyContains(rewriteHost),
 				},
 			})
 
-			By("the unmatched backend (httpbin.org -> 80) keeps the original host")
+			By("the other port keeps the original host")
 			s.RequestAssert(&scaffold.RequestAssert{
 				Method:  "GET",
 				Path:    "/headers",
-				Host:    "httpbin.org",
-				Headers: map[string]string{"Host": "httpbin.org"},
+				Host:    otherHost,
+				Headers: map[string]string{"Host": otherHost},
 				Checks: []scaffold.ResponseCheckFunc{
 					scaffold.WithExpectedStatus(200),
-					scaffold.WithExpectedBodyNotContains(rewrittenHost),
+					scaffold.WithExpectedBodyNotContains(rewriteHost),
 				},
 			})
+		}
+
+		It("attaches the policy to the http-v2 (8080) port when sectionName is http-v2", func() {
+			assertScopedToPort("http-v2", "httpbin.section-v2.example.com", "httpbin-v2.org", "httpbin.org")
+		})
+
+		It("attaches the policy to the http (80) port when sectionName is http", func() {
+			assertScopedToPort("http", "httpbin.section-http.example.com", "httpbin.org", "httpbin-v2.org")
 		})
 	})
 

--- a/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
+++ b/test/e2e/crds/v1alpha1/backendtrafficpolicy.go
@@ -206,34 +206,67 @@ spec:
 			s.ApplyHTTPRoute(types.NamespacedName{Namespace: s.Namespace(), Name: "httpbin-v2"}, fmt.Sprintf(routeToHTTPV2Port, s.Namespace(), s.Namespace()))
 		})
 
+		const rewrittenHost = "httpbin.section-v2.example.com"
+
 		It("should only attach to the backend matching sectionName", func() {
 			s.ResourceApplied("BackendTrafficPolicy", "httpbin", policyScopedToHTTPV2, 1)
 
-			By("policy applies to the http-v2 (8080) backend")
+			// Drive traffic to both hosts so both per-port upstreams are registered
+			// in the dataplane.
 			s.RequestAssert(&scaffold.RequestAssert{
-				Method: "GET",
-				Path:   "/headers",
-				Host:   "httpbin-v2.org",
-				Headers: map[string]string{
-					"Host": "httpbin-v2.org",
-				},
+				Method:  "GET",
+				Path:    "/headers",
+				Host:    "httpbin-v2.org",
+				Headers: map[string]string{"Host": "httpbin-v2.org"},
+				Checks:  []scaffold.ResponseCheckFunc{scaffold.WithExpectedStatus(200)},
+			})
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:  "GET",
+				Path:    "/headers",
+				Host:    "httpbin.org",
+				Headers: map[string]string{"Host": "httpbin.org"},
+				Checks:  []scaffold.ResponseCheckFunc{scaffold.WithExpectedStatus(200)},
+			})
+
+			// The Service is split into two per-port upstreams (http/80 and
+			// http-v2/8080) with identical nodes. The sectionName-scoped policy must
+			// attach to exactly one of them; under name-only matching it would attach
+			// to both (the whole Service), which this assertion rejects.
+			Eventually(func(g Gomega) {
+				ups, err := s.DefaultDataplaneResource().Upstream().List(context.Background())
+				g.Expect(err).ToNot(HaveOccurred(), "listing upstreams")
+				g.Expect(ups).To(HaveLen(2), "two per-port upstreams should exist")
+
+				var rewritten []*adctypes.Upstream
+				for _, u := range ups {
+					if u.PassHost == "rewrite" && u.UpstreamHost == rewrittenHost {
+						rewritten = append(rewritten, u)
+					}
+				}
+				g.Expect(rewritten).To(HaveLen(1), "policy must attach to exactly the sectionName-matched port, not the whole Service")
+			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
+
+			By("the matched backend (httpbin-v2.org -> 8080) reflects the rewritten host")
+			s.RequestAssert(&scaffold.RequestAssert{
+				Method:  "GET",
+				Path:    "/headers",
+				Host:    "httpbin-v2.org",
+				Headers: map[string]string{"Host": "httpbin-v2.org"},
 				Checks: []scaffold.ResponseCheckFunc{
 					scaffold.WithExpectedStatus(200),
-					scaffold.WithExpectedBodyContains("httpbin.section-v2.example.com"),
+					scaffold.WithExpectedBodyContains(rewrittenHost),
 				},
 			})
 
-			By("policy does not apply to the http (80) backend")
+			By("the unmatched backend (httpbin.org -> 80) keeps the original host")
 			s.RequestAssert(&scaffold.RequestAssert{
-				Method: "GET",
-				Path:   "/headers",
-				Host:   "httpbin.org",
-				Headers: map[string]string{
-					"Host": "httpbin.org",
-				},
+				Method:  "GET",
+				Path:    "/headers",
+				Host:    "httpbin.org",
+				Headers: map[string]string{"Host": "httpbin.org"},
 				Checks: []scaffold.ResponseCheckFunc{
 					scaffold.WithExpectedStatus(200),
-					scaffold.WithExpectedBodyNotContains("httpbin.section-v2.example.com"),
+					scaffold.WithExpectedBodyNotContains(rewrittenHost),
 				},
 			})
 		})


### PR DESCRIPTION
## What this does

Fixes #421.

`AttachBackendTrafficPolicyToUpstream` selected the policy to apply by matching only `targetRef.Name` and ignored `targetRef.sectionName` (and `group`/`kind`). As a result a `BackendTrafficPolicy` intended for a single named Service port was treated as if it applied to the entire Service.

For a `Service` target, the Gateway API interprets `sectionName` as the **port name**. This PR makes both attachment and conflict detection honor it:

- A `targetRef` **without** `sectionName` still applies to the whole Service (unchanged behavior).
- A `targetRef` **with** `sectionName` attaches only to the backend whose resolved Service port name matches it; a port-specific `targetRef` takes **precedence** over a whole-Service one.
- `targetRef` `group`/`kind` are matched against the backend ref (Gateway API defaults: empty group, `Service` kind) before matching by name.
- Per Gateway API semantics, a `sectionName` that cannot be resolved does **not** attach.
- Conflict detection (`ProcessBackendTrafficPolicy`) now scopes the conflict key by `sectionName`, so a port-scoped policy and a whole-Service policy (or two different-section policies) on the same Service can both be **Accepted** instead of one being marked `Conflicted`.

To resolve a backend's port name, the attachment function now also receives `tctx.Services` and maps the backend ref port number to the Service port name. All call sites (httproute / grpcroute / ingress / tcproute / tlsroute / udproute) are updated.

## Example / Reproduction

A Service that exposes two named ports backed by the same workload:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: httpbin
spec:
  selector: { app: httpbin }
  ports:
  - { name: http,    port: 80,   targetPort: 80 }
  - { name: http-v2, port: 8080, targetPort: 80 }
```

One HTTPRoute whose two rules send `/get` to port 80 and `/headers` to port 8080 (same Service, different ports):

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata: { name: httpbin }
spec:
  parentRefs: [{ name: apisix }]
  hostnames: ["httpbin.org"]
  rules:
  - matches: [{ path: { type: Exact, value: /get } }]
    backendRefs: [{ name: httpbin, port: 80 }]
  - matches: [{ path: { type: Exact, value: /headers } }]
    backendRefs: [{ name: httpbin, port: 8080 }]
```

Two policies — one scoped to the `http-v2` port via `sectionName`, one targeting the whole Service:

```yaml
apiVersion: apisix.apache.org/v1alpha1
kind: BackendTrafficPolicy
metadata: { name: per-port }
spec:
  targetRefs:
  - { name: httpbin, kind: Service, group: "", sectionName: http-v2 }
  passHost: rewrite
  upstreamHost: section.http-v2.example.com
---
apiVersion: apisix.apache.org/v1alpha1
kind: BackendTrafficPolicy
metadata: { name: whole }
spec:
  targetRefs:
  - { name: httpbin, kind: Service, group: "" }
  passHost: rewrite
  upstreamHost: whole.service.example.com
```

Expected result — both policies are accepted, and each port gets its own host:

```console
# port 8080 -> the per-port policy wins over the whole-Service one
$ curl -s http://<gateway>/headers -H 'Host: httpbin.org' | grep -i host
"Host": "section.http-v2.example.com"

# port 80 -> only the whole-Service policy applies
$ curl -s http://<gateway>/get -H 'Host: httpbin.org' | grep -i host
"Host": "whole.service.example.com"

# both policies are Accepted (neither is Conflicted)
$ kubectl get backendtrafficpolicy per-port whole \
    -o jsonpath='{.items[*].status.ancestors[*].conditions[?(@.type=="Accepted")].status}'
True True
```

**Before this fix:** the `per-port` policy leaked to port 80 as well (name-only match ignored `sectionName`), and the `whole` policy was rejected with `status.conditions[Accepted]=False, reason=Conflicted` ("Unable to target Service ... it conflicts with another BackendTrafficPolicy"), so port 80 received the wrong upstream host.

## Tests

- Unit tests (`TestAttachBackendTrafficPolicyToUpstreamSectionName`): sectionName match / mismatch (no attach) / no-sectionName whole-Service / port-specific precedence / cross-kind rejection.
- E2E (`test/e2e/crds/v1alpha1/backendtrafficpolicy.go`, `Section Name`): the example above — asserts the `http-v2` port uses the scoped policy while port 80 falls back to the whole-Service policy.

`go build`, `go vet`, and `go test ./internal/adc/translator/` all pass.
