### PR TITLE
fix: parse hmac-auth signed_headers from Secret as a header list

### DIFF
--- a/api/v2/apisixconsumer_types.go
+++ b/api/v2/apisixconsumer_types.go
@@ -165,6 +165,8 @@ type ApisixConsumerJwtAuthValue struct {
 // ApisixConsumerHMACAuth defines configuration for the HMAC authentication.
 type ApisixConsumerHMACAuth struct {
 	// SecretRef references a Kubernetes Secret containing the HMAC credentials.
+	// Unlike Value, the Secret stores signed_headers as a single string listing the
+	// header names separated by commas or whitespace, for example "X-Date, Host".
 	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
 	// Value specifies HMAC authentication credentials.
 	Value *ApisixConsumerHMACAuthValue `json:"value,omitempty" yaml:"value,omitempty"`

--- a/config/crd/bases/apisix.apache.org_apisixconsumers.yaml
+++ b/config/crd/bases/apisix.apache.org_apisixconsumers.yaml
@@ -82,8 +82,10 @@ spec:
                     description: HMACAuth configures the HMAC authentication details.
                     properties:
                       secretRef:
-                        description: SecretRef references a Kubernetes Secret containing
-                          the HMAC credentials.
+                        description: |-
+                          SecretRef references a Kubernetes Secret containing the HMAC credentials.
+                          Unlike Value, the Secret stores signed_headers as a single string listing the
+                          header names separated by commas or whitespace, for example "X-Date, Host".
                         properties:
                           name:
                             default: ""

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -896,7 +896,7 @@ ApisixConsumerHMACAuth defines configuration for the HMAC authentication.
 
 | Field | Description |
 | --- | --- |
-| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials. |
+| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials.<br />Unlike Value, the Secret stores signed_headers as a single string listing the<br />header names separated by commas or whitespace, for example "X-Date, Host". |
 | `value` _[ApisixConsumerHMACAuthValue](#apisixconsumerhmacauthvalue)_ | Value specifies HMAC authentication credentials. |
 
 

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -896,7 +896,7 @@ ApisixConsumerHMACAuth defines configuration for the HMAC authentication.
 
 | Field | Description |
 | --- | --- |
-| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials.<br />Unlike Value, the Secret stores signed_headers as a single string listing the<br />header names separated by commas or whitespace, for example "X-Date, Host". |
+| `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#localobjectreference-v1-core)_ | SecretRef references a Kubernetes Secret containing the HMAC credentials. Unlike Value, the Secret stores signed_headers as a single string listing the header names separated by commas or whitespace, for example "X-Date, Host". |
 | `value` _[ApisixConsumerHMACAuthValue](#apisixconsumerhmacauthvalue)_ | Value specifies HMAC authentication credentials. |
 
 

--- a/internal/adc/translator/apisixconsumer.go
+++ b/internal/adc/translator/apisixconsumer.go
@@ -20,6 +20,7 @@ package translator
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -307,15 +308,25 @@ func (t *Translator) translateConsumerHMACAuthPlugin(tctx *provider.TranslateCon
 	}
 
 	clockSkewRaw := sec.Data["clock_skew"]
-	clockSkew, _ := strconv.ParseInt(string(clockSkewRaw), 10, 64)
+	var clockSkew int64
+	if len(clockSkewRaw) > 0 {
+		var err error
+		clockSkew, err = strconv.ParseInt(string(clockSkewRaw), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("hmac-auth: invalid clock_skew %q in secret: %w", string(clockSkewRaw), err)
+		}
+	}
 	if clockSkew < 0 {
 		clockSkew = _hmacAuthClockSkewDefaultValue
 	}
 
+	// comma-separated header names, not raw bytes
 	signedHeadersRaw := sec.Data["signed_headers"]
-	signedHeaders := make([]string, 0, len(signedHeadersRaw))
-	for _, b := range signedHeadersRaw {
-		signedHeaders = append(signedHeaders, string(b))
+	var signedHeaders []string
+	for _, h := range strings.Split(string(signedHeadersRaw), ",") {
+		if h = strings.TrimSpace(h); h != "" {
+			signedHeaders = append(signedHeaders, h)
+		}
 	}
 
 	var keepHeader bool
@@ -355,7 +366,14 @@ func (t *Translator) translateConsumerHMACAuthPlugin(tctx *provider.TranslateCon
 	}
 
 	maxReqBodyRaw := sec.Data["max_req_body"]
-	maxReqBody, _ := strconv.ParseInt(string(maxReqBodyRaw), 10, 64)
+	var maxReqBody int64
+	if len(maxReqBodyRaw) > 0 {
+		var err error
+		maxReqBody, err = strconv.ParseInt(string(maxReqBodyRaw), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("hmac-auth: invalid max_req_body %q in secret: %w", string(maxReqBodyRaw), err)
+		}
+	}
 	if maxReqBody < 0 {
 		maxReqBody = _hmacAuthMaxReqBodyDefaultValue
 	}

--- a/internal/adc/translator/apisixconsumer.go
+++ b/internal/adc/translator/apisixconsumer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -313,21 +314,18 @@ func (t *Translator) translateConsumerHMACAuthPlugin(tctx *provider.TranslateCon
 		var err error
 		clockSkew, err = strconv.ParseInt(string(clockSkewRaw), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("hmac-auth: invalid clock_skew %q in secret: %w", string(clockSkewRaw), err)
+			return nil, fmt.Errorf("hmac-auth: invalid clock_skew %q in secret %s/%s: %w", string(clockSkewRaw), consumerNamespace, cfg.SecretRef.Name, err)
 		}
 	}
 	if clockSkew < 0 {
 		clockSkew = _hmacAuthClockSkewDefaultValue
 	}
 
-	// comma-separated header names, not raw bytes
+	// header names are RFC 7230 tokens, so a comma or any space is always a separator
 	signedHeadersRaw := sec.Data["signed_headers"]
-	var signedHeaders []string
-	for _, h := range strings.Split(string(signedHeadersRaw), ",") {
-		if h = strings.TrimSpace(h); h != "" {
-			signedHeaders = append(signedHeaders, h)
-		}
-	}
+	signedHeaders := strings.FieldsFunc(string(signedHeadersRaw), func(r rune) bool {
+		return r == ',' || unicode.IsSpace(r)
+	})
 
 	var keepHeader bool
 	keepHeaderRaw, ok := sec.Data["keep_headers"]
@@ -371,7 +369,7 @@ func (t *Translator) translateConsumerHMACAuthPlugin(tctx *provider.TranslateCon
 		var err error
 		maxReqBody, err = strconv.ParseInt(string(maxReqBodyRaw), 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("hmac-auth: invalid max_req_body %q in secret: %w", string(maxReqBodyRaw), err)
+			return nil, fmt.Errorf("hmac-auth: invalid max_req_body %q in secret %s/%s: %w", string(maxReqBodyRaw), consumerNamespace, cfg.SecretRef.Name, err)
 		}
 	}
 	if maxReqBody < 0 {

--- a/internal/adc/translator/apisixconsumer_test.go
+++ b/internal/adc/translator/apisixconsumer_test.go
@@ -23,12 +23,63 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/label"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 )
+
+func hmacConsumerWithSecret(name string) *apiv2.ApisixConsumer {
+	return &apiv2.ApisixConsumer{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: apiv2.ApisixConsumerSpec{
+			AuthParameter: &apiv2.ApisixConsumerAuthParameter{
+				HMACAuth: &apiv2.ApisixConsumerHMACAuth{
+					SecretRef: &corev1.LocalObjectReference{Name: name},
+				},
+			},
+		},
+	}
+}
+
+func TestTranslateApisixConsumer_HMACAuthSignedHeadersFromSecret(t *testing.T) {
+	translator := NewTranslator(logr.Discard())
+	tctx := provider.NewDefaultTranslateContext(context.Background())
+	tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = &corev1.Secret{
+		Data: map[string][]byte{
+			"key_id":         []byte("my-key"),
+			"secret_key":     []byte("my-secret"),
+			"signed_headers": []byte("X-Date, Host"),
+		},
+	}
+
+	result, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
+	require.NoError(t, err)
+	require.Len(t, result.Consumers, 1)
+
+	cfg := result.Consumers[0].Plugins["hmac-auth"].(*adctypes.HMACAuthConsumerConfig)
+	require.Equal(t, []string{"X-Date", "Host"}, cfg.SignedHeaders)
+}
+
+func TestTranslateApisixConsumer_HMACAuthRejectsInvalidClockSkew(t *testing.T) {
+	translator := NewTranslator(logr.Discard())
+	tctx := provider.NewDefaultTranslateContext(context.Background())
+	tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = &corev1.Secret{
+		Data: map[string][]byte{
+			"key_id":     []byte("my-key"),
+			"secret_key": []byte("my-secret"),
+			"clock_skew": []byte("3O0"), // typo: letter O
+		},
+	}
+
+	_, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "clock_skew")
+}
 
 func TestTranslateApisixConsumer_UsesMetadataLabelsWithoutOverwritingControllerLabels(t *testing.T) {
 	translator := NewTranslator(logr.Discard())

--- a/internal/adc/translator/apisixconsumer_test.go
+++ b/internal/adc/translator/apisixconsumer_test.go
@@ -33,52 +33,76 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 )
 
-func hmacConsumerWithSecret(name string) *apiv2.ApisixConsumer {
+func hmacConsumerWithSecret(secretName string) *apiv2.ApisixConsumer {
 	return &apiv2.ApisixConsumer{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
 		Spec: apiv2.ApisixConsumerSpec{
 			AuthParameter: &apiv2.ApisixConsumerAuthParameter{
 				HMACAuth: &apiv2.ApisixConsumerHMACAuth{
-					SecretRef: &corev1.LocalObjectReference{Name: name},
+					SecretRef: &corev1.LocalObjectReference{Name: secretName},
 				},
 			},
 		},
 	}
 }
 
-func TestTranslateApisixConsumer_HMACAuthSignedHeadersFromSecret(t *testing.T) {
-	translator := NewTranslator(logr.Discard())
-	tctx := provider.NewDefaultTranslateContext(context.Background())
-	tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = &corev1.Secret{
-		Data: map[string][]byte{
-			"key_id":         []byte("my-key"),
-			"secret_key":     []byte("my-secret"),
-			"signed_headers": []byte("X-Date, Host"),
-		},
-	}
-
-	result, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
-	require.NoError(t, err)
-	require.Len(t, result.Consumers, 1)
-
-	cfg := result.Consumers[0].Plugins["hmac-auth"].(*adctypes.HMACAuthConsumerConfig)
-	require.Equal(t, []string{"X-Date", "Host"}, cfg.SignedHeaders)
+func hmacSecret(data map[string][]byte) *corev1.Secret {
+	data["key_id"] = []byte("my-key")
+	data["secret_key"] = []byte("my-secret")
+	return &corev1.Secret{Data: data}
 }
 
-func TestTranslateApisixConsumer_HMACAuthRejectsInvalidClockSkew(t *testing.T) {
-	translator := NewTranslator(logr.Discard())
-	tctx := provider.NewDefaultTranslateContext(context.Background())
-	tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = &corev1.Secret{
-		Data: map[string][]byte{
-			"key_id":     []byte("my-key"),
-			"secret_key": []byte("my-secret"),
-			"clock_skew": []byte("3O0"), // typo: letter O
-		},
-	}
+func TestTranslateApisixConsumer_HMACAuthSignedHeadersFromSecret(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		raw      string
+		expected []string
+	}{
+		{name: "comma separated", raw: "X-Date,Host", expected: []string{"X-Date", "Host"}},
+		{name: "padding and empty entries", raw: " X-Date, , Host, ", expected: []string{"X-Date", "Host"}},
+		{name: "newline separated", raw: "X-Date\nHost", expected: []string{"X-Date", "Host"}},
+		{name: "space separated", raw: "X-Date Host", expected: []string{"X-Date", "Host"}},
+		{name: "single header", raw: "X-Date", expected: []string{"X-Date"}},
+		{name: "empty", raw: "", expected: []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			translator := NewTranslator(logr.Discard())
+			tctx := provider.NewDefaultTranslateContext(context.Background())
+			tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = hmacSecret(map[string][]byte{
+				"signed_headers": []byte(tc.raw),
+			})
 
-	_, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "clock_skew")
+			result, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
+			require.NoError(t, err)
+			require.Len(t, result.Consumers, 1)
+
+			cfg := result.Consumers[0].Plugins["hmac-auth"].(*adctypes.HMACAuthConsumerConfig)
+			require.Equal(t, tc.expected, cfg.SignedHeaders)
+		})
+	}
+}
+
+func TestTranslateApisixConsumer_HMACAuthRejectsUnparseableNumbers(t *testing.T) {
+	for _, tc := range []struct {
+		key string
+		raw string
+	}{
+		{key: "clock_skew", raw: "3O0"}, // typo: letter O
+		{key: "max_req_body", raw: "invalid"},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			translator := NewTranslator(logr.Discard())
+			tctx := provider.NewDefaultTranslateContext(context.Background())
+			tctx.Secrets[k8stypes.NamespacedName{Namespace: "default", Name: "hmac"}] = hmacSecret(map[string][]byte{
+				tc.key: []byte(tc.raw),
+			})
+
+			_, err := translator.TranslateApisixConsumer(tctx, hmacConsumerWithSecret("hmac"))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.key)
+			require.Contains(t, err.Error(), "default/hmac")
+		})
+	}
 }
 
 func TestTranslateApisixConsumer_UsesMetadataLabelsWithoutOverwritingControllerLabels(t *testing.T) {


### PR DESCRIPTION
### What this PR does

`translateConsumerHMACAuthPlugin` read `signed_headers` from a Secret by ranging over its raw bytes:

```go
signedHeadersRaw := sec.Data["signed_headers"] // []byte
for _, b := range signedHeadersRaw {           // ranges over bytes
    signedHeaders = append(signedHeaders, string(b)) // one 1-char entry per byte
}
```

Ranging over a `[]byte` yields `(index, byte)`, so `"X-Date,Host"` became `["X","-","D","a","t","e",",","H","o","s","t"]`. The data-plane hmac-auth policy then bound those single-character names into the signature, which never match real headers, so the operator's intended headers were silently **not** enforced as part of the HMAC signature. Only the `secretRef` path was affected; the inline `Value` path already passes a `[]string`.

### Fix

- Split the `signed_headers` value on commas and trim entries.
- Surface `strconv.ParseInt` failures for `clock_skew` and `max_req_body` instead of discarding them, so a typo no longer coerces silently to a default.

### Tests

- New unit tests: `signed_headers` from a Secret yields the correct header list; an unparseable `clock_skew` is rejected.

Paired open-source PR: apache/apisix-ingress-controller#2809. Fixes FINDING-050 (rfcs#184).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HMAC authentication secret handling by validating numeric settings and returning clear errors for invalid values.
  * Correctly parses `signed_headers` from Secrets by splitting on commas or whitespace, trimming entries, and ignoring empty values.
  * Keeps existing default behavior for negative or missing numeric settings.
* **Tests**
  * Added coverage for signed-header parsing across multiple input formats.
  * Added tests to ensure unparseable numeric fields are rejected with helpful error details.
* **Documentation**
  * Clarified `signed_headers` storage format for HMAC secret references in API docs and CRD schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->