### PR TITLE
fix: detect and warn on inconsistent SSL host/certificate configuration

### DIFF
--- a/internal/adc/translator/apisixtls.go
+++ b/internal/adc/translator/apisixtls.go
@@ -50,6 +50,14 @@ func (t *Translator) TranslateApisixTls(tctx *provider.TranslateContext, tls *ap
 		return nil, err
 	}
 
+	// APISIX serves the cert regardless of SAN, so this is advisory: warn when a
+	// declared host isn't covered by the cert SANs (clients may reject it).
+	if uncovered, sans := uncoveredSNIHosts(cert, tls.Spec.Hosts); len(uncovered) > 0 {
+		t.Log.Info("ApisixTls certificate does not cover all declared SNI hosts",
+			"namespace", tls.Namespace, "name", tls.Name,
+			"uncoveredHosts", uncovered, "certificateSANs", sans)
+	}
+
 	// Convert hosts to strings
 	snis := make([]string, len(tls.Spec.Hosts))
 	for i, host := range tls.Spec.Hosts {
@@ -96,4 +104,29 @@ func (t *Translator) TranslateApisixTls(tctx *provider.TranslateContext, tls *ap
 
 	result.SSL = append(result.SSL, ssl)
 	return result, nil
+}
+
+// uncoveredSNIHosts returns the declared hosts not covered by any DNS SAN in the
+// certificate (wildcard-aware), plus the cert SANs for logging. Returns nothing
+// when the cert declares no DNS SANs or can't be parsed, since coverage can't be
+// judged there.
+func uncoveredSNIHosts(cert []byte, hosts []apiv2.HostType) (uncovered []string, sans []string) {
+	sans, err := sslutils.ExtractHostsFromCertificate(cert)
+	if err != nil || len(sans) == 0 {
+		return nil, nil
+	}
+	for _, h := range hosts {
+		host := string(h)
+		covered := false
+		for _, san := range sans {
+			if sslutils.HostCoveredBy(host, san) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			uncovered = append(uncovered, host)
+		}
+	}
+	return uncovered, sans
 }

--- a/internal/adc/translator/apisixtls_test.go
+++ b/internal/adc/translator/apisixtls_test.go
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"slices"
+	"testing"
+	"time"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+)
+
+func genCertWithSANs(t *testing.T, sans []string) []byte {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	if err != nil {
+		t.Fatalf("failed to generate serial: %v", err)
+	}
+	cn := "test"
+	if len(sans) > 0 {
+		cn = sans[0]
+	}
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		DNSNames:              sans,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("failed to create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func hostTypes(hosts ...string) []apiv2.HostType {
+	out := make([]apiv2.HostType, 0, len(hosts))
+	for _, h := range hosts {
+		out = append(out, apiv2.HostType(h))
+	}
+	return out
+}
+
+func TestUncoveredSNIHosts(t *testing.T) {
+	cases := []struct {
+		name          string
+		sans          []string
+		hosts         []string
+		wantUncovered []string
+	}{
+		{"exact match", []string{"shop.example.com"}, []string{"shop.example.com"}, nil},
+		{"wildcard covers subdomain", []string{"*.example.com"}, []string{"shop.example.com"}, nil},
+		{"declared host not in SANs", []string{"internal.corp.local"}, []string{"shop.example.com"}, []string{"shop.example.com"}},
+		{"one of many uncovered", []string{"a.example.com"}, []string{"a.example.com", "b.example.com"}, []string{"b.example.com"}},
+		{"no DNS SANs is lenient", nil, []string{"shop.example.com"}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			uncovered, _ := uncoveredSNIHosts(genCertWithSANs(t, c.sans), hostTypes(c.hosts...))
+			if !slices.Equal(uncovered, c.wantUncovered) {
+				t.Fatalf("uncoveredSNIHosts() = %v, want %v", uncovered, c.wantUncovered)
+			}
+		})
+	}
+}

--- a/internal/ssl/util.go
+++ b/internal/ssl/util.go
@@ -218,6 +218,25 @@ func wildcardCovers(wildcard, host string) bool {
 	return label != "" && !strings.Contains(label, ".")
 }
 
+// HostCoveredBy reports whether a certificate SAN covers an SNI host. Coverage
+// is directional: an exact SAN covers only the identical host; a wildcard SAN
+// "*.suffix" covers single-label subdomains "<label>.suffix". A wildcard host is
+// covered only by an identical wildcard SAN (an exact SAN can't serve it).
+func HostCoveredBy(host, san string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	san = strings.ToLower(strings.TrimSpace(san))
+	if host == "" || san == "" {
+		return false
+	}
+	if host == san {
+		return true
+	}
+	if strings.HasPrefix(san, "*.") {
+		return wildcardCovers(san, host)
+	}
+	return false
+}
+
 // ParentWildcard returns the single-label covering wildcard for an exact host,
 // e.g. "app.example.com" -> "*.example.com". Returns "" if host is empty, is
 // itself a wildcard, or has no parent label.

--- a/internal/ssl/util.go
+++ b/internal/ssl/util.go
@@ -180,6 +180,58 @@ func NormalizeHosts(hosts []string) []string {
 	return normalized
 }
 
+// HostsOverlap reports whether two SNI host patterns can both match a common
+// concrete hostname. It understands single-label wildcards ("*.example.com"
+// matches "app.example.com" but not "a.b.example.com"). Two distinct wildcards
+// never share a concrete host.
+func HostsOverlap(a, b string) bool {
+	a = strings.ToLower(strings.TrimSpace(a))
+	b = strings.ToLower(strings.TrimSpace(b))
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	aWild := strings.HasPrefix(a, "*.")
+	bWild := strings.HasPrefix(b, "*.")
+	switch {
+	case aWild && bWild:
+		return false
+	case aWild:
+		return wildcardCovers(a, b)
+	case bWild:
+		return wildcardCovers(b, a)
+	default:
+		return false
+	}
+}
+
+// wildcardCovers reports whether wildcard "*.suffix" matches the exact host,
+// i.e. host is exactly "<single-label>.suffix".
+func wildcardCovers(wildcard, host string) bool {
+	suffix := wildcard[1:] // ".example.com"
+	if !strings.HasSuffix(host, suffix) {
+		return false
+	}
+	label := host[:len(host)-len(suffix)]
+	return label != "" && !strings.Contains(label, ".")
+}
+
+// ParentWildcard returns the single-label covering wildcard for an exact host,
+// e.g. "app.example.com" -> "*.example.com". Returns "" if host is empty, is
+// itself a wildcard, or has no parent label.
+func ParentWildcard(host string) string {
+	if host == "" || strings.HasPrefix(host, "*.") {
+		return ""
+	}
+	i := strings.IndexByte(host, '.')
+	if i < 0 || i == len(host)-1 {
+		return ""
+	}
+	return "*." + host[i+1:]
+}
+
 // CertificateHash returns the SHA-256 hash of the leaf certificate contained in the PEM data.
 // The hash is calculated from the DER-encoded bytes so that formatting differences (whitespace,
 // line endings, certificate ordering) do not affect the result.

--- a/internal/ssl/util_test.go
+++ b/internal/ssl/util_test.go
@@ -41,6 +41,28 @@ func TestHostsOverlap(t *testing.T) {
 	}
 }
 
+func TestHostCoveredBy(t *testing.T) {
+	cases := []struct {
+		host, san string
+		want      bool
+	}{
+		{"app.example.com", "app.example.com", true},       // exact SAN covers exact host
+		{"app.example.com", "*.example.com", true},         // wildcard SAN covers subdomain
+		{"App.Example.com", "*.EXAMPLE.com", true},         // case-insensitive
+		{"*.example.com", "*.example.com", true},           // wildcard host needs identical wildcard SAN
+		{"*.example.com", "app.example.com", false},        // exact SAN can't cover a wildcard host
+		{"a.b.example.com", "*.example.com", false},        // wildcard SAN is single-label only
+		{"shop.example.com", "internal.corp.local", false}, // unrelated SAN
+		{"example.com", "*.example.com", false},            // apex not covered by its wildcard
+		{"app.example.com", "", false},                     // empty SAN
+	}
+	for _, c := range cases {
+		if got := HostCoveredBy(c.host, c.san); got != c.want {
+			t.Errorf("HostCoveredBy(%q, %q) = %v, want %v", c.host, c.san, got, c.want)
+		}
+	}
+}
+
 func TestParentWildcard(t *testing.T) {
 	cases := []struct {
 		host, want string

--- a/internal/ssl/util_test.go
+++ b/internal/ssl/util_test.go
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssl
+
+import "testing"
+
+func TestHostsOverlap(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"example.com", "example.com", true},        // identical exact
+		{"*.example.com", "*.example.com", true},    // identical wildcard
+		{"app.example.com", "*.example.com", true},  // exact covered by wildcard
+		{"*.example.com", "app.example.com", true},  // wildcard covers exact (inverse)
+		{"App.Example.com", "*.EXAMPLE.com", true},  // case-insensitive
+		{"a.b.example.com", "*.example.com", false}, // multi-label not covered
+		{"example.com", "*.example.com", false},     // apex not covered by its wildcard
+		{"app.example.com", "app.other.com", false}, // different exacts
+		{"*.example.com", "*.other.com", false},     // distinct wildcards never overlap
+		{"*.a.example.com", "*.example.com", false}, // wildcards at different depths
+		{"", "example.com", false},                  // empty
+	}
+	for _, c := range cases {
+		if got := HostsOverlap(c.a, c.b); got != c.want {
+			t.Errorf("HostsOverlap(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestParentWildcard(t *testing.T) {
+	cases := []struct {
+		host, want string
+	}{
+		{"app.example.com", "*.example.com"},
+		{"example.com", "*.com"},
+		{"*.example.com", ""}, // already a wildcard
+		{"localhost", ""},     // no parent label
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := ParentWildcard(c.host); got != c.want {
+			t.Errorf("ParentWildcard(%q) = %q, want %q", c.host, got, c.want)
+		}
+	}
+}

--- a/internal/webhook/v1/apisixtls_webhook.go
+++ b/internal/webhook/v1/apisixtls_webhook.go
@@ -74,16 +74,17 @@ func (v *ApisixTlsCustomValidator) ValidateCreate(ctx context.Context, obj runti
 	}
 
 	detector := sslvalidator.NewConflictDetector(v.Client)
-	conflicts := detector.DetectConflicts(ctx, tls)
-	if len(conflicts) > 0 {
-		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
-	}
-
 	warnings := v.collectWarnings(ctx, tls)
+	// Overlapping SSL config is advisory: APISIX serves overlapping objects and
+	// resolves by SNI, so warn instead of denying.
+	skipADCValidation := v.initErr != nil || len(warnings) > 0
+	if conflicts := detector.DetectConflicts(ctx, tls); len(conflicts) > 0 {
+		warnings = append(warnings, sslvalidator.FormatConflicts(conflicts))
+	}
 	// Skip ADC validation when secrets are missing: the translator cannot
 	// load cert/key material, so validation would always fail. The missing-
 	// secret warnings are sufficient to inform the user.
-	if v.initErr != nil || len(warnings) > 0 {
+	if skipADCValidation {
 		return warnings, nil
 	}
 

--- a/internal/webhook/v1/gateway_webhook.go
+++ b/internal/webhook/v1/gateway_webhook.go
@@ -88,13 +88,14 @@ func (v *GatewayCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	}
 
 	detector := sslvalidator.NewConflictDetector(v.Client)
-	conflicts := detector.DetectConflicts(ctx, gateway)
-	if len(conflicts) > 0 {
-		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
-	}
-
 	warnings := v.warnIfMissingGatewayProxyForGateway(ctx, gateway)
 	warnings = append(warnings, v.collectReferenceWarnings(ctx, gateway)...)
+
+	// Overlapping SSL config is advisory: APISIX serves overlapping objects and
+	// resolves by SNI, so warn instead of denying.
+	if conflicts := detector.DetectConflicts(ctx, gateway); len(conflicts) > 0 {
+		warnings = append(warnings, sslvalidator.FormatConflicts(conflicts))
+	}
 
 	return warnings, nil
 }
@@ -117,13 +118,14 @@ func (v *GatewayCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	}
 
 	detector := sslvalidator.NewConflictDetector(v.Client)
-	conflicts := detector.DetectConflicts(ctx, gateway)
-	if len(conflicts) > 0 {
-		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
-	}
-
 	warnings := v.warnIfMissingGatewayProxyForGateway(ctx, gateway)
 	warnings = append(warnings, v.collectReferenceWarnings(ctx, gateway)...)
+
+	// Overlapping SSL config is advisory: APISIX serves overlapping objects and
+	// resolves by SNI, so warn instead of denying.
+	if conflicts := detector.DetectConflicts(ctx, gateway); len(conflicts) > 0 {
+		warnings = append(warnings, sslvalidator.FormatConflicts(conflicts))
+	}
 
 	return warnings, nil
 }

--- a/internal/webhook/v1/ingress_webhook.go
+++ b/internal/webhook/v1/ingress_webhook.go
@@ -77,12 +77,12 @@ func (v *IngressCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	}
 
 	detector := sslvalidator.NewConflictDetector(v.Client)
-	conflicts := detector.DetectConflicts(ctx, ingress)
-	if len(conflicts) > 0 {
-		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
-	}
-
 	warnings := v.collectReferenceWarnings(ctx, ingress)
+	// Overlapping SSL config is advisory: APISIX serves overlapping objects and
+	// resolves by SNI, so warn instead of denying.
+	if conflicts := detector.DetectConflicts(ctx, ingress); len(conflicts) > 0 {
+		warnings = append(warnings, sslvalidator.FormatConflicts(conflicts))
+	}
 	return warnings, nil
 }
 
@@ -98,12 +98,12 @@ func (v *IngressCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	}
 
 	detector := sslvalidator.NewConflictDetector(v.Client)
-	conflicts := detector.DetectConflicts(ctx, ingress)
-	if len(conflicts) > 0 {
-		return nil, fmt.Errorf("%s", sslvalidator.FormatConflicts(conflicts))
-	}
-
 	warnings := v.collectReferenceWarnings(ctx, ingress)
+	// Overlapping SSL config is advisory: APISIX serves overlapping objects and
+	// resolves by SNI, so warn instead of denying.
+	if conflicts := detector.DetectConflicts(ctx, ingress); len(conflicts) > 0 {
+		warnings = append(warnings, sslvalidator.FormatConflicts(conflicts))
+	}
 	return warnings, nil
 }
 

--- a/internal/webhook/v1/ssl/conflict_detector.go
+++ b/internal/webhook/v1/ssl/conflict_detector.go
@@ -282,10 +282,15 @@ func clientConfigHash(client *apiv2.ApisixMutualTlsClientConfig) string {
 	}
 	regexes := append([]string(nil), client.SkipMTLSUriRegex...)
 	sort.Strings(regexes)
-	canonical := fmt.Sprintf("ca=%s/%s;depth=%d;skip=%s",
-		client.CASecret.Namespace, client.CASecret.Name, client.Depth,
-		strings.Join(regexes, ","))
-	sum := sha256.Sum256([]byte(canonical))
+	// Length-prefix each regex so entries containing commas can't alias
+	// (e.g. {"a,b"} vs {"a","b"}), which would collide the hash.
+	var b strings.Builder
+	fmt.Fprintf(&b, "ca=%s/%s;depth=%d;skip=%d:",
+		client.CASecret.Namespace, client.CASecret.Name, client.Depth, len(regexes))
+	for _, r := range regexes {
+		fmt.Fprintf(&b, "%d:%s", len(r), r)
+	}
+	sum := sha256.Sum256([]byte(b.String()))
 	return hex.EncodeToString(sum[:])
 }
 

--- a/internal/webhook/v1/ssl/conflict_detector.go
+++ b/internal/webhook/v1/ssl/conflict_detector.go
@@ -136,12 +136,12 @@ func FormatConflicts(conflicts []SSLConflict) string {
 	if len(conflicts) == 0 {
 		return ""
 	}
-	var sb strings.Builder
-	sb.WriteString("SSL configuration conflicts detected:")
+	// Single line: admission warnings are HTTP headers, so newlines are dropped.
+	parts := make([]string, 0, len(conflicts))
 	for _, conflict := range conflicts {
-		sb.WriteString(fmt.Sprintf("\n- Host '%s' is already configured with a different certificate in %s", conflict.Host, conflict.ConflictingResource))
+		parts = append(parts, fmt.Sprintf("host '%s' is already configured with a different certificate in %s", conflict.Host, conflict.ConflictingResource))
 	}
-	return sb.String()
+	return "SSL configuration conflicts detected: " + strings.Join(parts, "; ")
 }
 
 // BuildGatewayMappings calculates host-to-certificate mappings for a Gateway.

--- a/internal/webhook/v1/ssl/conflict_detector.go
+++ b/internal/webhook/v1/ssl/conflict_detector.go
@@ -17,6 +17,8 @@ package ssl
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -42,7 +44,11 @@ var logger = log.Log.WithName("ssl-conflict-detector")
 type HostCertMapping struct {
 	Host            string
 	CertificateHash string
-	ResourceRef     string
+	// ClientConfigHash digests the mTLS client-verification config (CA ref, depth,
+	// skip regexes). Empty when the resource enforces no mTLS. Two resources for the
+	// same host+cert but differing client config are still a conflict.
+	ClientConfigHash string
+	ResourceRef      string
 }
 
 // SSLConflict exposes the conflict details to the admission webhook for reporting.
@@ -92,22 +98,23 @@ func (d *ConflictDetector) DetectConflicts(ctx context.Context, obj client.Objec
 	conflicts := make([]SSLConflict, 0)
 
 	// First, check for conflicts within the new resource itself.
-	seen := make(map[string]string, len(newMappings))
+	seen := make(map[string]HostCertMapping, len(newMappings))
 	for _, mapping := range newMappings {
 		if mapping.Host == "" || mapping.CertificateHash == "" {
 			continue
 		}
 		if prev, ok := seen[mapping.Host]; ok {
-			if prev != mapping.CertificateHash {
+			if prev.CertificateHash != mapping.CertificateHash ||
+				prev.ClientConfigHash != mapping.ClientConfigHash {
 				conflicts = append(conflicts, SSLConflict{
 					Host:                mapping.Host,
 					ConflictingResource: mapping.ResourceRef,
-					CertificateHash:     prev,
+					CertificateHash:     prev.CertificateHash,
 				})
 			}
 			continue
 		}
-		seen[mapping.Host] = mapping.CertificateHash
+		seen[mapping.Host] = mapping
 	}
 
 	if len(conflicts) > 0 {
@@ -251,15 +258,35 @@ func (d *ConflictDetector) BuildApisixTlsMappings(ctx context.Context, tls *apiv
 	// if len(hosts) == 0 {
 	// 	hosts = info.hosts
 	// }
+	clientHash := clientConfigHash(tls.Spec.Client)
 	for _, host := range hosts {
 		mappings = append(mappings, HostCertMapping{
-			Host:            host,
-			CertificateHash: info.hash,
-			ResourceRef:     fmt.Sprintf("%s/%s/%s", internaltypes.KindApisixTls, tls.Namespace, tls.Name),
+			Host:             host,
+			CertificateHash:  info.hash,
+			ClientConfigHash: clientHash,
+			ResourceRef:      fmt.Sprintf("%s/%s/%s", internaltypes.KindApisixTls, tls.Namespace, tls.Name),
 		})
 	}
 
 	return mappings
+}
+
+// clientConfigHash digests an ApisixTls mTLS client-verification config into a
+// stable key. Returns "" when no mTLS is configured, so a resource that enforces
+// mTLS and one that doesn't produce different keys for the same host+cert. It
+// keys on the CA secret reference (namespace/name), which uniquely identifies
+// the trust anchor, plus depth and the skip regexes.
+func clientConfigHash(client *apiv2.ApisixMutualTlsClientConfig) string {
+	if client == nil {
+		return ""
+	}
+	regexes := append([]string(nil), client.SkipMTLSUriRegex...)
+	sort.Strings(regexes)
+	canonical := fmt.Sprintf("ca=%s/%s;depth=%d;skip=%s",
+		client.CASecret.Namespace, client.CASecret.Name, client.Depth,
+		strings.Join(regexes, ","))
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:])
 }
 
 func (d *ConflictDetector) getSecretInfo(ctx context.Context, nn types.NamespacedName) (*secretInfo, error) {
@@ -324,10 +351,10 @@ func (d *ConflictDetector) resolveGatewayProxy(ctx context.Context, obj client.O
 	}
 }
 
-func (d *ConflictDetector) findExternalConflicts(ctx context.Context, obj client.Object, gatewayProxy *v1alpha1.GatewayProxy, hosts map[string]string) ([]SSLConflict, error) {
+func (d *ConflictDetector) findExternalConflicts(ctx context.Context, obj client.Object, gatewayProxy *v1alpha1.GatewayProxy, newMappings map[string]HostCertMapping) ([]SSLConflict, error) {
 	excludeUID := obj.GetUID()
-	hostValues := make([]string, 0, len(hosts))
-	for host := range hosts {
+	hostValues := make([]string, 0, len(newMappings))
+	for host := range newMappings {
 		hostValues = append(hostValues, host)
 	}
 	sort.Strings(hostValues)
@@ -338,24 +365,54 @@ func (d *ConflictDetector) findExternalConflicts(ctx context.Context, obj client
 
 	var noHostCandidates []client.Object
 	noHostFetched := false
+	var allTLSResources []client.Object
+	allFetched := false
 
 	for _, host := range hostValues {
-		candidates, err := d.listResourcesByHost(ctx, host)
-		if err != nil {
-			logger.Error(err, "failed to list resources by host", "host", host)
-			return nil, err
-		}
-		if host != "" {
-			if !noHostFetched {
-				// List resources with empty host.
-				noHostCandidates, err = d.listResourcesByHost(ctx, "")
+		var (
+			candidates []client.Object
+			err        error
+		)
+		if strings.HasPrefix(host, "*.") {
+			// A wildcard covers many exact hosts; the host index can't answer a
+			// suffix query, so enumerate all TLS resources and filter by overlap.
+			if !allFetched {
+				allTLSResources, err = d.listAllTLSResources(ctx)
 				if err != nil {
-					logger.Error(err, "failed to list resources by host", "host", "", "object", objectKey(obj))
+					logger.Error(err, "failed to list TLS resources", "object", objectKey(obj))
 					return nil, err
 				}
-				noHostFetched = true
+				allFetched = true
 			}
-			candidates = mergeCandidateObjects(candidates, noHostCandidates)
+			candidates = allTLSResources
+		} else {
+			candidates, err = d.listResourcesByHost(ctx, host)
+			if err != nil {
+				logger.Error(err, "failed to list resources by host", "host", host)
+				return nil, err
+			}
+			// Also look up a covering wildcard, which is indexed under a
+			// different key (e.g. "*.example.com" for host "app.example.com").
+			if parent := sslutil.ParentWildcard(host); parent != "" {
+				wildcardCandidates, err := d.listResourcesByHost(ctx, parent)
+				if err != nil {
+					logger.Error(err, "failed to list resources by host", "host", parent)
+					return nil, err
+				}
+				candidates = mergeCandidateObjects(candidates, wildcardCandidates)
+			}
+			if host != "" {
+				if !noHostFetched {
+					// List resources with empty host.
+					noHostCandidates, err = d.listResourcesByHost(ctx, "")
+					if err != nil {
+						logger.Error(err, "failed to list resources by host", "host", "", "object", objectKey(obj))
+						return nil, err
+					}
+					noHostFetched = true
+				}
+				candidates = mergeCandidateObjects(candidates, noHostCandidates)
+			}
 		}
 		for _, candidate := range candidates {
 			if candidate.GetUID() == excludeUID {
@@ -376,8 +433,12 @@ func (d *ConflictDetector) findExternalConflicts(ctx context.Context, obj client
 			if !ok {
 				continue
 			}
-			// same cert hash, no conflict
-			if mapping.CertificateHash == hosts[host] {
+			// Same server cert AND same mTLS client config: no conflict. A
+			// differing client config is still a conflict even when the server
+			// cert matches.
+			newMapping := newMappings[host]
+			if mapping.CertificateHash == newMapping.CertificateHash &&
+				mapping.ClientConfigHash == newMapping.ClientConfigHash {
 				continue
 			}
 
@@ -407,6 +468,39 @@ func (d *ConflictDetector) findExternalConflicts(ctx context.Context, obj client
 	for _, key := range keys {
 		results = append(results, conflictSet[key])
 	}
+	return results, nil
+}
+
+// listAllTLSResources enumerates every TLS-bearing Gateway, Ingress and
+// ApisixTls. Used when the incoming host is a wildcard, whose covered exact
+// hosts can't be resolved through the exact-key host index.
+func (d *ConflictDetector) listAllTLSResources(ctx context.Context) ([]client.Object, error) {
+	results := make([]client.Object, 0)
+
+	var gatewayList gatewayv1.GatewayList
+	if err := d.client.List(ctx, &gatewayList); err != nil {
+		return nil, err
+	}
+	for i := range gatewayList.Items {
+		results = append(results, gatewayList.Items[i].DeepCopy())
+	}
+
+	var ingressList networkingv1.IngressList
+	if err := d.client.List(ctx, &ingressList); err != nil {
+		return nil, err
+	}
+	for i := range ingressList.Items {
+		results = append(results, ingressList.Items[i].DeepCopy())
+	}
+
+	var tlsList apiv2.ApisixTlsList
+	if err := d.client.List(ctx, &tlsList); err != nil {
+		return nil, err
+	}
+	for i := range tlsList.Items {
+		results = append(results, tlsList.Items[i].DeepCopy())
+	}
+
 	return results, nil
 }
 
@@ -478,7 +572,12 @@ func (d *ConflictDetector) mappingForHostWithCache(ctx context.Context, obj clie
 	}
 
 	for _, mapping := range mappings {
-		if mapping.Host == host {
+		if mapping.Host == "" {
+			continue
+		}
+		// Wildcard-aware: an exact host and a covering wildcard overlap even
+		// though their index keys differ ("app.example.com" vs "*.example.com").
+		if sslutil.HostsOverlap(mapping.Host, host) {
 			return mapping, true
 		}
 	}

--- a/internal/webhook/v1/ssl/conflict_detector_test.go
+++ b/internal/webhook/v1/ssl/conflict_detector_test.go
@@ -31,7 +31,9 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -383,6 +385,193 @@ func TestConflictDetectorDetectsSelfConflict(t *testing.T) {
 	expectedRef := fmt.Sprintf("Gateway/%s/%s", gateway.Namespace, gateway.Name)
 	if conflict.ConflictingResource != expectedRef {
 		t.Fatalf("unexpected conflicting resource: %s, expected %s", conflict.ConflictingResource, expectedRef)
+	}
+}
+
+// newApisixTls builds an ApisixTls bound to the shared testIngressClass.
+func newApisixTls(name, uid string, hosts []string, secret *corev1.Secret) *apiv2.ApisixTls {
+	hostTypes := make([]apiv2.HostType, 0, len(hosts))
+	for _, h := range hosts {
+		hostTypes = append(hostTypes, apiv2.HostType(h))
+	}
+	return &apiv2.ApisixTls{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			UID:       types.UID(uid),
+		},
+		Spec: apiv2.ApisixTlsSpec{
+			IngressClassName: testIngressClass,
+			Hosts:            hostTypes,
+			Secret: apiv2.ApisixSecret{
+				Name:      secret.Name,
+				Namespace: secret.Namespace,
+			},
+		},
+	}
+}
+
+func buildConflictClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := buildScheme(t)
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&gatewayv1.Gateway{}, indexer.ParametersRef, indexer.GatewayParametersRefIndexFunc).
+		WithIndex(&gatewayv1.Gateway{}, indexer.TLSHostIndexRef, indexer.GatewayTLSHostIndexFunc).
+		WithIndex(&networkingv1.IngressClass{}, indexer.IngressClassParametersRef, indexer.IngressClassParametersRefIndexFunc).
+		WithIndex(&networkingv1.Ingress{}, indexer.IngressClassRef, indexer.IngressClassRefIndexFunc).
+		WithIndex(&networkingv1.Ingress{}, indexer.TLSHostIndexRef, indexer.IngressTLSHostIndexFunc).
+		WithIndex(&apiv2.ApisixTls{}, indexer.IngressClassRef, indexer.ApisixTlsIngressClassIndexFunc).
+		WithIndex(&apiv2.ApisixTls{}, indexer.TLSHostIndexRef, indexer.ApisixTlsHostIndexFunc).
+		WithObjects(objs...).
+		Build()
+}
+
+func sharedIngressClassFixtures() (*v1alpha1.GatewayProxy, *networkingv1.IngressClass) {
+	gatewayProxy := &v1alpha1.GatewayProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-gp",
+			Namespace: testNamespace,
+			UID:       "gatewayproxy-uid-wildcard",
+		},
+	}
+	ingressClass := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{Name: testIngressClass},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: config.ControllerConfig.ControllerName,
+			Parameters: &networkingv1.IngressClassParametersReference{
+				APIGroup:  ptr.To(v1alpha1.GroupVersion.Group),
+				Kind:      internaltypes.KindGatewayProxy,
+				Name:      gatewayProxy.Name,
+				Namespace: ptr.To(testNamespace),
+			},
+		},
+	}
+	return gatewayProxy, ingressClass
+}
+
+// TestConflictDetectorDetectsExactOverlappingWildcard verifies an incoming
+// exact host conflicts with an existing covering wildcard, even though the two
+// are indexed under different keys.
+func TestConflictDetectorDetectsExactOverlappingWildcard(t *testing.T) {
+	existingSecret := newTLSSecret(t, "existing-cert", []string{"*.example.com"})
+	incomingSecret := newTLSSecret(t, "incoming-cert", []string{"app.example.com"})
+	gatewayProxy, ingressClass := sharedIngressClassFixtures()
+
+	existing := newApisixTls("existing", "existing-uid", []string{"*.example.com"}, existingSecret)
+	incoming := newApisixTls("incoming", "incoming-uid", []string{"app.example.com"}, incomingSecret)
+
+	c := buildConflictClient(t, existingSecret, incomingSecret, gatewayProxy, ingressClass, existing)
+	detector := NewConflictDetector(c)
+
+	conflicts := detector.DetectConflicts(context.Background(), incoming)
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d: %+v", len(conflicts), conflicts)
+	}
+	if conflicts[0].Host != "app.example.com" {
+		t.Fatalf("unexpected host: %s", conflicts[0].Host)
+	}
+	expectedRef := fmt.Sprintf("ApisixTls/%s/%s", existing.Namespace, existing.Name)
+	if conflicts[0].ConflictingResource != expectedRef {
+		t.Fatalf("unexpected conflicting resource: %s", conflicts[0].ConflictingResource)
+	}
+}
+
+// TestConflictDetectorDetectsWildcardOverlappingExact verifies the inverse: an
+// incoming wildcard conflicts with an existing exact host it covers.
+func TestConflictDetectorDetectsWildcardOverlappingExact(t *testing.T) {
+	existingSecret := newTLSSecret(t, "existing-cert", []string{"app.example.com"})
+	incomingSecret := newTLSSecret(t, "incoming-cert", []string{"*.example.com"})
+	gatewayProxy, ingressClass := sharedIngressClassFixtures()
+
+	existing := newApisixTls("existing", "existing-uid", []string{"app.example.com"}, existingSecret)
+	incoming := newApisixTls("incoming", "incoming-uid", []string{"*.example.com"}, incomingSecret)
+
+	c := buildConflictClient(t, existingSecret, incomingSecret, gatewayProxy, ingressClass, existing)
+	detector := NewConflictDetector(c)
+
+	conflicts := detector.DetectConflicts(context.Background(), incoming)
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d: %+v", len(conflicts), conflicts)
+	}
+	if conflicts[0].Host != "*.example.com" {
+		t.Fatalf("unexpected host: %s", conflicts[0].Host)
+	}
+}
+
+// TestConflictDetectorAllowsNonOverlappingWildcard guards against false
+// positives: a wildcard and an unrelated exact host must not conflict.
+func TestConflictDetectorAllowsNonOverlappingWildcard(t *testing.T) {
+	existingSecret := newTLSSecret(t, "existing-cert", []string{"a.b.example.com"})
+	incomingSecret := newTLSSecret(t, "incoming-cert", []string{"*.example.com"})
+	gatewayProxy, ingressClass := sharedIngressClassFixtures()
+
+	existing := newApisixTls("existing", "existing-uid", []string{"a.b.example.com"}, existingSecret)
+	incoming := newApisixTls("incoming", "incoming-uid", []string{"*.example.com"}, incomingSecret)
+
+	c := buildConflictClient(t, existingSecret, incomingSecret, gatewayProxy, ingressClass, existing)
+	detector := NewConflictDetector(c)
+
+	conflicts := detector.DetectConflicts(context.Background(), incoming)
+	if len(conflicts) != 0 {
+		t.Fatalf("expected no conflict (multi-label host not covered by wildcard), got %+v", conflicts)
+	}
+}
+
+// newApisixTlsMTLS builds an ApisixTls with an optional mTLS client config.
+func newApisixTlsMTLS(name, uid string, hosts []string, secret *corev1.Secret, client *apiv2.ApisixMutualTlsClientConfig) *apiv2.ApisixTls {
+	tls := newApisixTls(name, uid, hosts, secret)
+	tls.Spec.Client = client
+	return tls
+}
+
+// TestConflictDetectorDetectsDifferingMTLS verifies an incoming resource with
+// the same host and server cert but no mTLS conflicts with an existing resource
+// that enforces mTLS.
+func TestConflictDetectorDetectsDifferingMTLS(t *testing.T) {
+	sharedSecret := newTLSSecret(t, "shared-cert", []string{"api.example.com"})
+	gatewayProxy, ingressClass := sharedIngressClassFixtures()
+
+	mtls := &apiv2.ApisixMutualTlsClientConfig{
+		CASecret: apiv2.ApisixSecret{Name: "client-ca", Namespace: testNamespace},
+		Depth:    1,
+	}
+	existing := newApisixTlsMTLS("existing", "existing-uid", []string{"api.example.com"}, sharedSecret, mtls)
+	incoming := newApisixTlsMTLS("incoming", "incoming-uid", []string{"api.example.com"}, sharedSecret, nil)
+
+	c := buildConflictClient(t, sharedSecret, gatewayProxy, ingressClass, existing)
+	detector := NewConflictDetector(c)
+
+	conflicts := detector.DetectConflicts(context.Background(), incoming)
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict (differing mTLS config), got %d: %+v", len(conflicts), conflicts)
+	}
+	if conflicts[0].Host != "api.example.com" {
+		t.Fatalf("unexpected host: %s", conflicts[0].Host)
+	}
+}
+
+// TestConflictDetectorAllowsIdenticalMTLS guards against false positives: same
+// host, same server cert, same mTLS client config must not conflict.
+func TestConflictDetectorAllowsIdenticalMTLS(t *testing.T) {
+	sharedSecret := newTLSSecret(t, "shared-cert", []string{"api.example.com"})
+	gatewayProxy, ingressClass := sharedIngressClassFixtures()
+
+	mtls := func() *apiv2.ApisixMutualTlsClientConfig {
+		return &apiv2.ApisixMutualTlsClientConfig{
+			CASecret: apiv2.ApisixSecret{Name: "client-ca", Namespace: testNamespace},
+			Depth:    1,
+		}
+	}
+	existing := newApisixTlsMTLS("existing", "existing-uid", []string{"api.example.com"}, sharedSecret, mtls())
+	incoming := newApisixTlsMTLS("incoming", "incoming-uid", []string{"api.example.com"}, sharedSecret, mtls())
+
+	c := buildConflictClient(t, sharedSecret, gatewayProxy, ingressClass, existing)
+	detector := NewConflictDetector(c)
+
+	conflicts := detector.DetectConflicts(context.Background(), incoming)
+	if len(conflicts) != 0 {
+		t.Fatalf("expected no conflict (identical mTLS config), got %+v", conflicts)
 	}
 }
 

--- a/internal/webhook/v1/ssl/conflict_detector_test.go
+++ b/internal/webhook/v1/ssl/conflict_detector_test.go
@@ -575,6 +575,21 @@ func TestConflictDetectorAllowsIdenticalMTLS(t *testing.T) {
 	}
 }
 
+// TestClientConfigHashInjectiveOnCommaRegex guards the skip-regex encoding:
+// {"a,b"} and {"a","b"} are different configs and must not hash alike.
+func TestClientConfigHashInjectiveOnCommaRegex(t *testing.T) {
+	ca := apiv2.ApisixSecret{Name: "client-ca", Namespace: testNamespace}
+	single := clientConfigHash(&apiv2.ApisixMutualTlsClientConfig{
+		CASecret: ca, SkipMTLSUriRegex: []string{"a,b"},
+	})
+	split := clientConfigHash(&apiv2.ApisixMutualTlsClientConfig{
+		CASecret: ca, SkipMTLSUriRegex: []string{"a", "b"},
+	})
+	if single == split {
+		t.Fatalf("distinct skip-regex configs collided: %s", single)
+	}
+}
+
 func generateCertificate(t *testing.T, hosts []string) ([]byte, []byte) {
 	t.Helper()
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/test/e2e/webhook/ssl_conflict.go
+++ b/test/e2e/webhook/ssl_conflict.go
@@ -47,7 +47,7 @@ var _ = Describe("Test SSL/TLS Conflict Detection", Label("webhook"), func() {
 	})
 
 	Context("ApisixTls conflict detection", func() {
-		It("should reject ApisixTls with conflicting certificate for same host", func() {
+		It("should warn about ApisixTls with conflicting certificate for same host", func() {
 			host := "conflict.example.com"
 			secretA := "tls-cert-a"
 			secretB := "tls-cert-b"
@@ -90,11 +90,11 @@ spec:
     namespace: %s
 `, s.Namespace(), s.Namespace(), host, secretB, s.Namespace())
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(tlsBYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating ApisixTls B")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
-				g.Expect(err.Error()).To(ContainSubstring("ApisixTls"))
+				output, err := s.CreateResourceFromStringAndGetOutput(tlsBYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
+				g.Expect(output).To(ContainSubstring("ApisixTls"))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
@@ -146,7 +146,7 @@ spec:
 	})
 
 	Context("Gateway and ApisixTls conflict detection", func() {
-		It("should reject Gateway with conflicting certificate against existing ApisixTls", func() {
+		It("should warn about Gateway with conflicting certificate against existing ApisixTls", func() {
 			host := "gateway-vs-tls.example.com"
 			secretA := "gateway-cert-a"
 			secretB := "gateway-cert-b"
@@ -199,10 +199,10 @@ spec:
       name: apisix-proxy-config
 `, s.Namespace(), s.Namespace(), hostname, secretB)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(gatewayYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating Gateway")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(gatewayYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
@@ -262,7 +262,7 @@ spec:
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
-		It("should reject ApisixTls when Gateway without hostname uses different certificate", func() {
+		It("should warn about ApisixTls when Gateway without hostname uses different certificate", func() {
 			host := "gateway-no-host-conflict.example.com"
 			secretA := "gateway-no-host-cert-a"
 			secretB := "gateway-no-host-cert-b"
@@ -313,16 +313,16 @@ spec:
     namespace: %s
 `, s.Namespace(), s.Namespace(), host, secretB, s.Namespace())
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(tlsYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating ApisixTls without hostname on existing Gateway")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(tlsYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 	})
 
 	Context("Gateway self-conflict detection", func() {
-		It("should reject Gateway with multiple listeners using different certificates for same host", func() {
+		It("should warn about Gateway with multiple listeners using different certificates for same host", func() {
 			host := "self-conflict.example.com"
 			secretA := "gateway-self-cert-a"
 			secretB := "gateway-self-cert-b"
@@ -365,16 +365,16 @@ spec:
       name: apisix-proxy-config
 `, s.Namespace(), s.Namespace(), hostname, secretA, hostname, secretB)
 			Eventually(func(g Gomega) {
-				err := s.CreateResourceFromString(gatewayYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting self-conflict in Gateway")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(gatewayYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 	})
 
 	Context("Ingress conflict detection", func() {
-		It("should reject Ingress with conflicting certificate in its own TLS config", func() {
+		It("should warn about Ingress with conflicting certificate in its own TLS config", func() {
 			host := "ingress-self-conflict.example.com"
 			secretA := "ingress-self-cert-a"
 			secretB := "ingress-self-cert-b"
@@ -429,14 +429,14 @@ spec:
               number: 80
 `, s.Namespace(), s.Namespace(), host, secretA, host, secretB, host)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(ingressYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting self-conflict in Ingress")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(ingressYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
-		It("should reject Ingress with conflicting certificate against existing ApisixTls", func() {
+		It("should warn about Ingress with conflicting certificate against existing ApisixTls", func() {
 			host := "ingress-vs-tls.example.com"
 			secretA := "ingress-cert-a"
 			secretB := "ingress-cert-b"
@@ -506,10 +506,10 @@ spec:
               number: 80
 `, s.Namespace(), s.Namespace(), host, secretB, host)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(ingressYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating Ingress")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(ingressYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
@@ -596,7 +596,7 @@ spec:
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
-		It("should reject Ingress when Gateway without hostname uses different certificate", func() {
+		It("should warn about Ingress when Gateway without hostname uses different certificate", func() {
 			host := "gateway-ingress-no-host-conflict.example.com"
 			secretA := "gateway-ingress-no-host-cert-a"
 			secretB := "gateway-ingress-no-host-cert-b"
@@ -671,16 +671,16 @@ spec:
               number: 80
 `, s.Namespace(), s.Namespace(), secretB)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(ingressYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating Ingress without hostname")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(ingressYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 	})
 
 	Context("Default IngressClass conflict detection", func() {
-		It("should reject Ingress without explicit class when default class uses a different certificate", func() {
+		It("should warn about Ingress without explicit class when default class uses a different certificate", func() {
 			host := "default-ingress-conflict.example.com"
 			secretA := "default-ingress-cert-a"
 			secretB := "default-ingress-cert-b"
@@ -779,14 +779,14 @@ spec:
               number: 80
 `, s.Namespace(), host, secretB, host)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(ingressBYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating second Ingress")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(ingressBYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
-		It("should reject ApisixTls without explicit class when default class uses a different certificate", func() {
+		It("should warn about ApisixTls without explicit class when default class uses a different certificate", func() {
 			host := "default-tls-conflict.example.com"
 			secretA := "default-tls-cert-a"
 			secretB := "default-tls-cert-b"
@@ -848,16 +848,16 @@ spec:
     namespace: %s
 `, s.Namespace(), host, secretB, s.Namespace())
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(tlsBYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating second ApisixTls")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(tlsBYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 	})
 
 	Context("Update scenario conflict detection", func() {
-		It("should reject Ingress update that switches to a conflicting certificate", func() {
+		It("should warn about Ingress update that switches to a conflicting certificate", func() {
 			host := "ingress-update-conflict.example.com"
 			secretA := "ingress-update-cert-a"
 			secretB := "ingress-update-cert-b"
@@ -955,14 +955,14 @@ spec:
               number: 80
 `, s.Namespace(), s.Namespace(), host, secretB, host)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(ingressUpdatedYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when updating Ingress certificate")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(ingressUpdatedYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 
-		It("should reject Gateway update that switches to a conflicting certificate", func() {
+		It("should warn about Gateway update that switches to a conflicting certificate", func() {
 			host := "gateway-update-conflict.example.com"
 			secretA := "gateway-update-cert-a"
 			secretB := "gateway-update-cert-b"
@@ -1041,10 +1041,10 @@ spec:
       name: apisix-proxy-config
 `, s.Namespace(), s.Namespace(), host, secretB)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(gatewayUpdatedYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when updating Gateway certificate")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
-				g.Expect(err.Error()).To(ContainSubstring(host))
+				output, err := s.CreateResourceFromStringAndGetOutput(gatewayUpdatedYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
+				g.Expect(output).To(ContainSubstring(host))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 	})
@@ -1105,9 +1105,9 @@ spec:
     namespace: %s
 `, s.Namespace(), s.Namespace(), host, secretB, s.Namespace())
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(tlsYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating ApisixTls with different cert")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
+				output, err := s.CreateResourceFromStringAndGetOutput(tlsYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 
 			By("creating a backend service")
@@ -1153,9 +1153,9 @@ spec:
               number: 80
 `, s.Namespace(), s.Namespace(), host, secretC, host)
 			Eventually(func(g Gomega) {
-				err = s.CreateResourceFromString(ingressYAML)
-				g.Expect(err).Should(HaveOccurred(), "expecting conflict when creating Ingress with different cert")
-				g.Expect(err.Error()).To(ContainSubstring("SSL configuration conflicts detected"))
+				output, err := s.CreateResourceFromStringAndGetOutput(ingressYAML)
+				g.Expect(err).NotTo(HaveOccurred(), "overlap should be admitted and reported as a warning")
+				g.Expect(output).To(ContainSubstring("SSL configuration conflicts detected"))
 			}).WithTimeout(scaffold.DefaultTimeout).ProbeEvery(scaffold.DefaultInterval).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
### Description

Ports the SSL host/certificate consistency work from apache/apisix-ingress-controller#2810. The SSL conflict detector now **warns** on overlap instead of **denying** it at admission, and its detection is made wildcard- and mTLS-aware so the warnings are accurate.

**1. Wildcard vs. exact host matching** — hosts were compared by exact string equality, so `*.example.com` and `app.example.com` (different index keys) were never compared; APISIX resolves exact SNI ahead of a covering wildcard, so they collide. Add `sslutil.HostsOverlap` / `ParentWildcard`; exact host also queries its covering wildcard, wildcard host enumerates + filters by overlap; compare with `HostsOverlap`.

**2. mTLS client config in the conflict key** — keyed only on server cert hash. Add `ClientConfigHash` (CA secret ref + depth + skip regex; empty when no mTLS).

**3. Overlap reported as a warning, not a denial** — the detector previously rejected overlapping objects at admission. That gate misses conflicts from a cert rotating inside its Secret, a `GatewayProxy`/`IngressClass` regrouping, a disabled webhook, or pre-existing objects, and blocks edits to already-coexisting configs. Now surfaced as an admission **warning** on create/update. The reconcile-time status-condition treatment is tracked in #448.

**4. Certificate SAN coverage warning (translator)** — `TranslateApisixTls` gave no signal when cert SANs don't cover a declared host; now logs a warning via `sslutil.HostCoveredBy` (APISIX serves the cert regardless).

### Notes

- Internal tracking: FINDING-020 / FINDING-021 / FINDING-022 (api7/rfcs#154, #155, #156). Follow-up: #448.
- Two-PR sync with apache/apisix-ingress-controller#2810; code hunks word-for-word identical. Neither PR blocks the other.

### Tests

- unit tests for `HostsOverlap` / `ParentWildcard` / `HostCoveredBy`
- detector tests for wildcard/exact overlap (both directions) and differing mTLS, with false-positive guards
- translator tests for SAN coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wildcard-aware TLS conflict detection for overlapping exact and wildcard host patterns.
  - Reduced false-positive conflicts for non-overlapping wildcard/exact combinations.
  - TLS conflict checks now include mTLS client-verification settings (not only certificate identity).
  - Webhooks now surface overlapping SSL configuration conflicts as advisory warnings rather than denying admission.
  - TLS translation now adds an informational check for SNI hosts not covered by certificate DNS SANs (no rejection; lenient when no DNS SANs).
- **Tests**
  - Added unit tests for hostname overlap/coverage and parent wildcard derivation.
  - Expanded webhook and translator test coverage for wildcard overlap, mTLS differences, and uncovered SNI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->