### PR TITLE
fix: verify control-plane TLS certificate by default

### DIFF
--- a/api/v1alpha1/gatewayproxy_types.go
+++ b/api/v1alpha1/gatewayproxy_types.go
@@ -133,7 +133,10 @@ type ControlPlaneProvider struct {
 
 	Service *ProviderService `json:"service,omitempty"`
 	// TlsVerify specifies whether to verify the TLS certificate of the control plane.
+	// Defaults to true. Setting it to false disables certificate verification and
+	// exposes the AdminKey to man-in-the-middle attacks over https endpoints.
 	// +optional
+	// +kubebuilder:default=true
 	TlsVerify *bool `json:"tlsVerify,omitempty"`
 
 	// Auth specifies the authentication configuration.

--- a/config/crd-nocel/apisix.apache.org_v2.yaml
+++ b/config/crd-nocel/apisix.apache.org_v2.yaml
@@ -2295,8 +2295,11 @@ spec:
                         - name
                         type: object
                       tlsVerify:
-                        description: TlsVerify specifies whether to verify the TLS
-                          certificate of the control plane.
+                        default: true
+                        description: |-
+                          TlsVerify specifies whether to verify the TLS certificate of the control plane.
+                          Defaults to true. Setting it to false disables certificate verification and
+                          exposes the AdminKey to man-in-the-middle attacks over https endpoints.
                         type: boolean
                     required:
                     - auth

--- a/config/crd/bases/apisix.apache.org_gatewayproxies.yaml
+++ b/config/crd/bases/apisix.apache.org_gatewayproxies.yaml
@@ -147,8 +147,11 @@ spec:
                         - name
                         type: object
                       tlsVerify:
-                        description: TlsVerify specifies whether to verify the TLS
-                          certificate of the control plane.
+                        default: true
+                        description: |-
+                          TlsVerify specifies whether to verify the TLS certificate of the control plane.
+                          Defaults to true. Setting it to false disables certificate verification and
+                          exposes the AdminKey to man-in-the-middle attacks over https endpoints.
                         type: boolean
                     required:
                     - auth

--- a/docs/en/latest/reference/api-reference.md
+++ b/docs/en/latest/reference/api-reference.md
@@ -312,7 +312,7 @@ ControlPlaneProvider defines configuration for control plane provider.
 | `mode` _string_ | Mode specifies the mode of control plane provider. Can be `apisix` or `apisix-standalone`. |
 | `endpoints` _string array_ | Endpoints specifies the list of control plane endpoints. |
 | `service` _[ProviderService](#providerservice)_ |  |
-| `tlsVerify` _boolean_ | TlsVerify specifies whether to verify the TLS certificate of the control plane. |
+| `tlsVerify` _boolean_ | TlsVerify specifies whether to verify the TLS certificate of the control plane. Defaults to true. Setting it to false disables certificate verification and exposes the AdminKey to man-in-the-middle attacks over https endpoints. |
 | `auth` _[ControlPlaneAuth](#controlplaneauth)_ | Auth specifies the authentication configuration. |
 
 

--- a/internal/adc/translator/gatewayproxy.go
+++ b/internal/adc/translator/gatewayproxy.go
@@ -52,6 +52,9 @@ func (t *Translator) TranslateGatewayProxyToConfig(tctx *provider.TranslateConte
 		BackendType: cp.Mode,
 	}
 
+	// Verify the control plane's TLS certificate by default; only an explicit
+	// tlsVerify:false opts out.
+	cfg.TlsVerify = true
 	if cp.TlsVerify != nil {
 		cfg.TlsVerify = *cp.TlsVerify
 	}

--- a/internal/adc/translator/gatewayproxy_test.go
+++ b/internal/adc/translator/gatewayproxy_test.go
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
+	"github.com/apache/apisix-ingress-controller/internal/provider"
+)
+
+func TestTranslateGatewayProxyToConfig_TlsVerifyDefault(t *testing.T) {
+	newProxy := func(tlsVerify *bool) *v1alpha1.GatewayProxy {
+		return &v1alpha1.GatewayProxy{
+			ObjectMeta: metav1.ObjectMeta{Name: "gp", Namespace: "default"},
+			Spec: v1alpha1.GatewayProxySpec{
+				Provider: &v1alpha1.GatewayProxyProvider{
+					Type: v1alpha1.ProviderTypeControlPlane,
+					ControlPlane: &v1alpha1.ControlPlaneProvider{
+						Endpoints: []string{"https://127.0.0.1:7443"},
+						TlsVerify: tlsVerify,
+						Auth: v1alpha1.ControlPlaneAuth{
+							Type:     v1alpha1.AuthTypeAdminKey,
+							AdminKey: &v1alpha1.AdminKeyAuth{Value: "secret"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tr := false
+	tt := true
+	cases := []struct {
+		name      string
+		tlsVerify *bool
+		want      bool
+	}{
+		{"unset defaults to verify", nil, true},
+		{"explicit false opts out", &tr, false},
+		{"explicit true verifies", &tt, true},
+	}
+
+	translator := NewTranslator(logr.Discard())
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tctx := provider.NewDefaultTranslateContext(context.Background())
+			cfg, err := translator.TranslateGatewayProxyToConfig(tctx, newProxy(c.tlsVerify), false)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			require.Equal(t, c.want, cfg.TlsVerify)
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

`GatewayProxy` `spec.provider.controlPlane.tlsVerify` is a `*bool` with no default. When omitted (as the shipped example manifests do, while pointing at `https://` Admin API endpoints), it decodes to `nil`, the translator leaves `cfg.TlsVerify` at the Go zero value `false`, and the executor inverts that into `tlsSkipVerify: true`. The result is that a default install skips certificate verification on the connection that carries the AdminKey and the full gateway config.

This makes verification the secure default:

- `+kubebuilder:default=true` on the CRD field, so an omitted `tlsVerify` becomes `true`.
- `cfg.TlsVerify = true` in the translator before honoring an explicit value, so behavior is correct even against an older CRD without the default. Only an explicit `tlsVerify: false` opts out.
- Regenerated CRD manifests (bases + crd-nocel) and API reference docs; documented that setting it to `false` disables certificate verification.

## Testing

Added a translator unit test asserting the default: unset -> verify, explicit `false` -> skip, explicit `true` -> verify.

```
go test ./internal/adc/translator/ -run TestTranslateGatewayProxyToConfig_TlsVerifyDefault
```

Synced with apache/apisix-ingress-controller#2811.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TLS certificate verification now defaults to enabled when `tlsVerify` is not specified.
  * Explicitly setting `tlsVerify: false` continues to disable certificate verification.

* **Documentation**
  * Updated API and CRD field descriptions to include the default behavior and security warning about disabling TLS verification (including potential man-in-the-middle risk to AdminKey exposure).

* **Tests**
  * Added coverage to ensure the translator applies the `tlsVerify` default and honors explicit `true/false` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->