### PR TITLE
fix: never treat an unreachable API server as a missing API resource

### DIFF
--- a/.github/workflows/apisix-e2e-test.yml
+++ b/.github/workflows/apisix-e2e-test.yml
@@ -103,7 +103,9 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.cjs adc.js
+          # main.cjs lives in the image's WORKDIR, not at the container root,
+          # and docker cp resolves a relative SRC_PATH against the root.
+          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/.github/workflows/e2e-test-k8s.yml
+++ b/.github/workflows/e2e-test-k8s.yml
@@ -106,7 +106,9 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.cjs adc.js
+          # main.cjs lives in the image's WORKDIR, not at the container root,
+          # and docker cp resolves a relative SRC_PATH against the root.
+          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -105,7 +105,9 @@ jobs:
         if: ${{ env.ADC_VERSION == 'dev' }}
         run: |
           docker create --name adc-temp ghcr.io/api7/adc:dev
-          docker cp adc-temp:main.cjs adc.js
+          # main.cjs lives in the image's WORKDIR, not at the container root,
+          # and docker cp resolves a relative SRC_PATH against the root.
+          docker cp "adc-temp:$(docker inspect -f '{{.Config.WorkingDir}}' adc-temp)/main.cjs" adc.js
           docker rm adc-temp
           node $(pwd)/adc.js -v
           echo "ADC_BIN=node $(pwd)/adc.js" >> $GITHUB_ENV

--- a/internal/controller/apisixroute_controller.go
+++ b/internal/controller/apisixroute_controller.go
@@ -71,7 +71,11 @@ type ApisixRouteReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *ApisixRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Check and store EndpointSlice API support
-	r.supportsEndpointSlice = pkgutils.HasAPIResource(mgr, &discoveryv1.EndpointSlice{})
+	supportsEndpointSlice, err := pkgutils.HasAPIResource(mgr, &discoveryv1.EndpointSlice{})
+	if err != nil {
+		return err
+	}
+	r.supportsEndpointSlice = supportsEndpointSlice
 	var icWatch client.Object
 	switch r.ICGV.String() {
 	case networkingv1beta1.SchemeGroupVersion.String():

--- a/internal/controller/consumer_controller.go
+++ b/internal/controller/consumer_controller.go
@@ -62,7 +62,14 @@ type ConsumerReconciler struct { //nolint:revive
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if config.ControllerConfig.DisableGatewayAPI || !pkgutils.HasAPIResource(mgr, &gatewayv1.Gateway{}) {
+	hasGatewayAPI := false
+	if !config.ControllerConfig.DisableGatewayAPI {
+		var err error
+		if hasGatewayAPI, err = pkgutils.HasAPIResource(mgr, &gatewayv1.Gateway{}); err != nil {
+			return err
+		}
+	}
+	if !hasGatewayAPI {
 		r.Log.Info("skipping Consumer controller setup as Gateway API is not available")
 		return nil
 	}

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -103,19 +103,31 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(referenceGrantPredicates(KindGateway)),
 		)
 	}
-	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TCPRoute{}) {
+	hasTCPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TCPRoute{})
+	if err != nil {
+		return err
+	}
+	if hasTCPRoute {
 		bdr.Watches(
 			&gatewayv1alpha2.TCPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
-	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TLSRoute{}) {
+	hasTLSRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TLSRoute{})
+	if err != nil {
+		return err
+	}
+	if hasTLSRoute {
 		bdr.Watches(
 			&gatewayv1alpha2.TLSRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
-	if pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.UDPRoute{}) {
+	hasUDPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.UDPRoute{})
+	if err != nil {
+		return err
+	}
+	if hasUDPRoute {
 		bdr.Watches(
 			&gatewayv1alpha2.UDPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),

--- a/internal/controller/gatewayproxy_controller.go
+++ b/internal/controller/gatewayproxy_controller.go
@@ -61,8 +61,17 @@ type GatewayProxyController struct {
 
 func (r *GatewayProxyController) SetupWithManager(mrg ctrl.Manager) error {
 	// Check and store EndpointSlice API support
-	r.supportsEndpointSlice = pkgutils.HasAPIResource(mrg, &discoveryv1.EndpointSlice{})
-	r.supportsGateway = pkgutils.HasAPIResource(mrg, &gatewayv1.Gateway{}) && !config.ControllerConfig.DisableGatewayAPI
+	supportsEndpointSlice, err := pkgutils.HasAPIResource(mrg, &discoveryv1.EndpointSlice{})
+	if err != nil {
+		return err
+	}
+	r.supportsEndpointSlice = supportsEndpointSlice
+
+	if !config.ControllerConfig.DisableGatewayAPI {
+		if r.supportsGateway, err = pkgutils.HasAPIResource(mrg, &gatewayv1.Gateway{}); err != nil {
+			return err
+		}
+	}
 	var icWatch client.Object
 	switch r.ICGV.String() {
 	case networkingv1beta1.SchemeGroupVersion.String():

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -76,7 +76,11 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.genericEvent = make(chan event.GenericEvent, 100)
 
 	// Check and store EndpointSlice API support
-	r.supportsEndpointSlice = pkgutils.HasAPIResource(mgr, &discoveryv1.EndpointSlice{})
+	supportsEndpointSlice, err := pkgutils.HasAPIResource(mgr, &discoveryv1.EndpointSlice{})
+	if err != nil {
+		return err
+	}
+	r.supportsEndpointSlice = supportsEndpointSlice
 
 	eventFilters := []predicate.Predicate{
 		predicate.GenerationChangedPredicate{},

--- a/internal/controller/indexer/indexer.go
+++ b/internal/controller/indexer/indexer.go
@@ -74,12 +74,16 @@ func SetupIndexer(mgr ctrl.Manager) error {
 			&gatewayv1.GatewayClass{}:   setupGatewayClassIndexer,
 			&v1alpha1.Consumer{}:        setupConsumerIndexer,
 		} {
-			if utils.HasAPIResource(mgr, resource) {
-				if err := setup(mgr); err != nil {
-					return err
-				}
-			} else {
+			installed, err := utils.HasAPIResource(mgr, resource)
+			if err != nil {
+				return err
+			}
+			if !installed {
 				setupLog.Info("Skipping indexer setup, API not found in cluster", "api", utils.FormatGVK(resource))
+				continue
+			}
+			if err := setup(mgr); err != nil {
+				return err
 			}
 		}
 	}
@@ -92,12 +96,16 @@ func SetupIndexer(mgr ctrl.Manager) error {
 		&v1alpha1.HTTPRoutePolicy{}:       setHTTPRoutePolicyIndexer,
 		&v1alpha1.L4RoutePolicy{}:         setupL4RoutePolicyIndexer,
 	} {
-		if utils.HasAPIResource(mgr, resource) {
-			if err := setup(mgr); err != nil {
-				return err
-			}
-		} else {
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
+		}
+		if !installed {
 			setupLog.Info("Skipping indexer setup, API not found in cluster", "api", utils.FormatGVK(resource))
+			continue
+		}
+		if err := setup(mgr); err != nil {
+			return err
 		}
 	}
 

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -73,7 +73,11 @@ func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.genericEvent = make(chan event.GenericEvent, 100)
 
 	// Check and store EndpointSlice API support
-	r.supportsEndpointSlice = pkgutils.HasAPIResource(mgr, &discoveryv1.EndpointSlice{})
+	supportsEndpointSlice, err := pkgutils.HasAPIResource(mgr, &discoveryv1.EndpointSlice{})
+	if err != nil {
+		return err
+	}
+	r.supportsEndpointSlice = supportsEndpointSlice
 
 	eventFilters := []predicate.Predicate{
 		predicate.GenerationChangedPredicate{},

--- a/internal/controller/tcproute_controller.go
+++ b/internal/controller/tcproute_controller.go
@@ -101,7 +101,11 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// L4RoutePolicy is an optional CRD. Only watch it when installed so the
 	// controller still starts if the CRD has not been applied yet (e.g. upgrades).
-	r.supportsL4RoutePolicy = pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	supportsL4RoutePolicy, err := pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	if err != nil {
+		return err
+	}
+	r.supportsL4RoutePolicy = supportsL4RoutePolicy
 	if r.supportsL4RoutePolicy {
 		bdr.Watches(&v1alpha1.L4RoutePolicy{},
 			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForL4RoutePolicy),

--- a/internal/controller/tlsroute_controller.go
+++ b/internal/controller/tlsroute_controller.go
@@ -101,7 +101,11 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// L4RoutePolicy is an optional CRD. Only watch it when installed so the
 	// controller still starts if the CRD has not been applied yet (e.g. upgrades).
-	r.supportsL4RoutePolicy = pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	supportsL4RoutePolicy, err := pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	if err != nil {
+		return err
+	}
+	r.supportsL4RoutePolicy = supportsL4RoutePolicy
 	if r.supportsL4RoutePolicy {
 		bdr.Watches(&v1alpha1.L4RoutePolicy{},
 			handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForL4RoutePolicy),

--- a/internal/controller/udproute_controller.go
+++ b/internal/controller/udproute_controller.go
@@ -101,7 +101,11 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// L4RoutePolicy is an optional CRD. Only watch it when installed so the
 	// controller still starts if the CRD has not been applied yet (e.g. upgrades).
-	r.supportsL4RoutePolicy = pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	supportsL4RoutePolicy, err := pkgutils.HasAPIResource(mgr, &v1alpha1.L4RoutePolicy{})
+	if err != nil {
+		return err
+	}
+	r.supportsL4RoutePolicy = supportsL4RoutePolicy
 	if r.supportsL4RoutePolicy {
 		bdr.Watches(&v1alpha1.L4RoutePolicy{},
 			handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForL4RoutePolicy),

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -119,7 +119,11 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 	var controllers []Controller
 
 	icgv := netv1.SchemeGroupVersion
-	if !utils.HasAPIResource(mgr, &netv1.IngressClass{}) {
+	hasIngressClassV1, err := utils.HasAPIResource(mgr, &netv1.IngressClass{})
+	if err != nil {
+		return nil, err
+	}
+	if !hasIngressClassV1 {
 		setupLog.Info("IngressClass v1 not found, falling back to IngressClass v1beta1")
 		icgv = netv1beta1.SchemeGroupVersion
 		controllers = append(controllers, &controller.IngressClassV1beta1Reconciler{
@@ -195,7 +199,11 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 				Readier:  readier,
 			},
 		} {
-			if utils.HasAPIResource(mgr, resource) {
+			installed, err := utils.HasAPIResource(mgr, resource)
+			if err != nil {
+				return nil, err
+			}
+			if installed {
 				controllers = append(controllers, controller)
 			} else {
 				setupLog.Info("Skipping controller setup, API not found in cluster", "api", utils.FormatGVK(resource))
@@ -221,7 +229,11 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 			Provider: pro,
 		},
 	} {
-		if utils.HasAPIResource(mgr, resource) {
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return nil, err
+		}
+		if installed {
 			controllers = append(controllers, controller)
 		} else {
 			setupLog.Info("Skipping controller setup, API not found in cluster", "api", utils.FormatGVK(resource))
@@ -293,29 +305,43 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 	return controllers, nil
 }
 
-func registerReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager) {
+func registerReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager) error {
 	log := ctrl.LoggerFrom(context.Background()).WithName("readiness")
 
-	registerV2ForReadinessGVK(mgr, readier, log)
-	if !config.ControllerConfig.DisableGatewayAPI {
-		registerGatewayAPIForReadinessGVK(mgr, readier, log)
-		registerV1alpha1ForReadinessGVK(mgr, readier, log)
-	} else {
-		log.Info("Skipping Gateway API and v1alpha1 GVK registration for readiness checks as Gateway API is disabled")
+	if err := registerV2ForReadinessGVK(mgr, readier, log); err != nil {
+		return err
 	}
+	if config.ControllerConfig.DisableGatewayAPI {
+		log.Info("Skipping Gateway API and v1alpha1 GVK registration for readiness checks as Gateway API is disabled")
+		return nil
+	}
+	if err := registerGatewayAPIForReadinessGVK(mgr, readier, log); err != nil {
+		return err
+	}
+	return registerV1alpha1ForReadinessGVK(mgr, readier, log)
 }
 
-func registerV2ForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager, log logr.Logger) {
+func registerV2ForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager, log logr.Logger) error {
 	icgv := netv1.SchemeGroupVersion
-	if !utils.HasAPIResource(mgr, &netv1.IngressClass{}) {
+	hasIngressClassV1, err := utils.HasAPIResource(mgr, &netv1.IngressClass{})
+	if err != nil {
+		return err
+	}
+	if !hasIngressClassV1 {
 		icgv = netv1beta1.SchemeGroupVersion
 	}
 
 	resources := v2ReadinessResources()
 	gvks := make([]schema.GroupVersionKind, 0, len(resources))
 	for _, resource := range resources {
-		if _, ok := resource.(*netv1.Ingress); ok && !utils.HasAPIResource(mgr, resource) {
-			continue
+		if _, ok := resource.(*netv1.Ingress); ok {
+			installed, err := utils.HasAPIResource(mgr, resource)
+			if err != nil {
+				return err
+			}
+			if !installed {
+				continue
+			}
 		}
 		gvks = append(gvks, types.GvkOf(resource))
 	}
@@ -330,6 +356,7 @@ func registerV2ForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessM
 		}),
 	})
 	log.Info("Registered v2 GVKs for readiness checks", "gvks", gvks)
+	return nil
 }
 
 func v2ReadinessResources() []client.Object {
@@ -342,45 +369,53 @@ func v2ReadinessResources() []client.Object {
 	}
 }
 
-func registerGatewayAPIForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager, log logr.Logger) {
-	gvks := []schema.GroupVersionKind{}
-	if utils.HasAPIResource(mgr, &gatewayv1.HTTPRoute{}) {
-		gvks = append(gvks, types.GvkOf(&gatewayv1.HTTPRoute{}))
+func registerGatewayAPIForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager, log logr.Logger) error {
+	resources := []client.Object{
+		&gatewayv1.HTTPRoute{},
+		&gatewayv1.GRPCRoute{},
+		&gatewayv1alpha2.TCPRoute{},
+		&gatewayv1alpha2.UDPRoute{},
+		&gatewayv1alpha2.TLSRoute{},
 	}
-	if utils.HasAPIResource(mgr, &gatewayv1.GRPCRoute{}) {
-		gvks = append(gvks, types.GvkOf(&gatewayv1.GRPCRoute{}))
-	}
-	if utils.HasAPIResource(mgr, &gatewayv1alpha2.TCPRoute{}) {
-		gvks = append(gvks, types.GvkOf(&gatewayv1alpha2.TCPRoute{}))
-	}
-	if utils.HasAPIResource(mgr, &gatewayv1alpha2.UDPRoute{}) {
-		gvks = append(gvks, types.GvkOf(&gatewayv1alpha2.UDPRoute{}))
-	}
-	if utils.HasAPIResource(mgr, &gatewayv1alpha2.TLSRoute{}) {
-		gvks = append(gvks, types.GvkOf(&gatewayv1alpha2.TLSRoute{}))
+	gvks := make([]schema.GroupVersionKind, 0, len(resources))
+	for _, resource := range resources {
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
+		}
+		if !installed {
+			continue
+		}
+		gvks = append(gvks, types.GvkOf(resource))
 	}
 	if len(gvks) == 0 {
-		return
+		return nil
 	}
 
 	readier.RegisterGVK(readiness.GVKConfig{
 		GVKs: gvks,
 	})
 	log.Info("Registered Gateway API GVKs for readiness checks", "gvks", gvks)
+	return nil
 }
 
-func registerV1alpha1ForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager, log logr.Logger) {
-	gvks := []schema.GroupVersionKind{}
-
-	for _, resource := range []client.Object{
+func registerV1alpha1ForReadinessGVK(mgr manager.Manager, readier readiness.ReadinessManager, log logr.Logger) error {
+	resources := []client.Object{
 		&v1alpha1.Consumer{},
-	} {
-		if utils.HasAPIResource(mgr, resource) {
-			gvks = append(gvks, types.GvkOf(resource))
+	}
+	gvks := make([]schema.GroupVersionKind, 0, len(resources))
+	for _, resource := range resources {
+		installed, err := utils.HasAPIResource(mgr, resource)
+		if err != nil {
+			return err
 		}
+		if !installed {
+			continue
+		}
+		gvks = append(gvks, types.GvkOf(resource))
 	}
 	if len(gvks) == 0 {
-		return
+		return nil
 	}
 	c := mgr.GetClient()
 	readier.RegisterGVK(readiness.GVKConfig{
@@ -394,4 +429,5 @@ func registerV1alpha1ForReadinessGVK(mgr manager.Manager, readier readiness.Read
 		}),
 	})
 	log.Info("Registered v1alpha1 GVKs for readiness checks", "gvks", gvks)
+	return nil
 }

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-logr/logr"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
@@ -48,6 +47,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 	_ "github.com/apache/apisix-ingress-controller/internal/provider/init"
 	_ "github.com/apache/apisix-ingress-controller/pkg/metrics"
+	"github.com/apache/apisix-ingress-controller/pkg/utils"
 )
 
 var (
@@ -82,6 +82,11 @@ func Run(ctx context.Context, logger logr.Logger) error {
 	cfg := config.ControllerConfig
 
 	setupLog := ctrl.LoggerFrom(ctx).WithName("setup")
+
+	// SetupSignalHandler must be called exactly once. Install it before setup
+	// starts so that a shutdown signal is honored while waiting for the API
+	// server, not only once the manager is running.
+	signalCtx := ctrl.SetupSignalHandler()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -168,8 +173,37 @@ func Run(ctx context.Context, logger logr.Logger) error {
 		return err
 	}
 
+	// Which API resources are installed is detected once, below, and gates the
+	// registration of field indexes, controllers and readiness checks for the
+	// whole lifetime of the process. Detecting them against an unreachable API
+	// server would silently classify everything as "not installed" and leave the
+	// controller permanently degraded until it is restarted, so wait for the API
+	// server to answer first.
+	if err := utils.WaitForAPIServer(signalCtx, mgr.GetConfig(), setupLog); err != nil {
+		setupLog.Error(err, "unable to reach the Kubernetes API server")
+		return err
+	}
+
+	// API resource detection runs outside the manager and does not observe
+	// signalCtx, so check between setup phases: now that the signal handler is
+	// installed this early, a shutdown signal would otherwise be swallowed until
+	// mgr.Start.
+	checkShutdown := func() error {
+		if err := signalCtx.Err(); err != nil {
+			setupLog.Info("shutdown requested during setup, stopping", "reason", err)
+			return err
+		}
+		return nil
+	}
+
 	readier := readiness.NewReadinessManager(mgr.GetClient(), logger)
-	registerReadinessGVK(mgr, readier)
+	if err := registerReadinessGVK(mgr, readier); err != nil {
+		setupLog.Error(err, "unable to register readiness checks")
+		return err
+	}
+	if err := checkShutdown(); err != nil {
+		return err
+	}
 
 	if err := mgr.Add(readier); err != nil {
 		setupLog.Error(err, "unable to add readiness manager")
@@ -207,16 +241,26 @@ func Run(ctx context.Context, logger logr.Logger) error {
 		return err
 	}
 
-	setupLog.Info("check ReferenceGrants is enabled")
-	_, err = mgr.GetRESTMapper().KindsFor(schema.GroupVersionResource{
-		Group:    v1beta1.GroupVersion.Group,
-		Version:  v1beta1.GroupVersion.Version,
-		Resource: "referencegrants",
-	})
-	if err != nil {
-		setupLog.Info("CRD ReferenceGrants is not installed", "err", err)
+	// ReferenceGrant is a Gateway API kind and only consulted by Gateway API
+	// paths, so skip the detection entirely when Gateway API is disabled.
+	hasReferenceGrant := false
+	if config.ControllerConfig.DisableGatewayAPI {
+		setupLog.Info("Gateway API is disabled, skipping the ReferenceGrants check")
+	} else {
+		setupLog.Info("check ReferenceGrants is enabled")
+		if hasReferenceGrant, err = utils.HasAPIResource(mgr, &v1beta1.ReferenceGrant{}); err != nil {
+			setupLog.Error(err, "unable to detect whether ReferenceGrants is installed")
+			return err
+		}
+		if !hasReferenceGrant {
+			setupLog.Info("CRD ReferenceGrants is not installed, cross-namespace references will be rejected",
+				"gvk", utils.FormatGVK(&v1beta1.ReferenceGrant{}))
+		}
 	}
-	controller.SetEnableReferenceGrant(err == nil)
+	controller.SetEnableReferenceGrant(hasReferenceGrant)
+	if err := checkShutdown(); err != nil {
+		return err
+	}
 
 	setupLog.Info("setting up controllers")
 	controllers, err := setupControllers(ctx, mgr, provider, updater.Writer(), readier)
@@ -227,6 +271,9 @@ func Run(ctx context.Context, logger logr.Logger) error {
 
 	for _, c := range controllers {
 		if err := c.SetupWithManager(mgr); err != nil {
+			return err
+		}
+		if err := checkShutdown(); err != nil {
 			return err
 		}
 	}
@@ -256,5 +303,5 @@ func Run(ctx context.Context, logger logr.Logger) error {
 	}
 
 	setupLog.Info("starting controller manager")
-	return mgr.Start(ctrl.SetupSignalHandler())
+	return mgr.Start(signalCtx)
 }

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -81,12 +81,12 @@ func apiServerWaitBackoff() wait.Backoff {
 
 // HasAPIResource reports whether the API resource of obj is served by the cluster.
 //
-// An error is returned when discovery cannot produce a definitive answer, for
-// instance because the API server is unreachable. Callers must not fall back to
-// "resource absent" in that case: detection runs once at startup and gates field
-// index, controller and readiness registration, so a temporary API server outage
-// would otherwise leave the controller permanently degraded until it is
-// restarted.
+// Only a 404 from discovery reports the resource as absent. Every other failure
+// returns an error, including a Forbidden discovery request: callers must not
+// fall back to "resource absent" there. Detection runs once at startup and gates
+// field index, controller and readiness registration, so an API server outage or
+// an RBAC mistake would otherwise leave the controller permanently degraded
+// until it is restarted.
 func HasAPIResource(mgr ctrl.Manager, obj client.Object) (bool, error) {
 	return HasAPIResourceWithLogger(mgr, obj, ctrl.Log.WithName("api-detection"))
 }
@@ -136,11 +136,12 @@ func hasAPIResource(
 		logger.Info("group/version not available in cluster", "error", err)
 		return false, nil
 	case apierrors.IsForbidden(err):
-		// Definitive, but a misconfiguration rather than an absent CRD: log loudly
-		// so it is not mistaken for "the CRD was never installed".
-		logger.Error(err, "discovery is forbidden, treating the API resource as not installed; "+
-			"check the discovery permissions of the controller service account")
-		return false, nil
+		// Definitive, but no evidence of absence: the resource may well be served
+		// and only discovery is denied. Resolving it to "absent" would be cached
+		// for the lifetime of the manager and permanently skip the controller, so
+		// an RBAC misconfiguration must abort startup instead.
+		return false, fmt.Errorf("discovery of %s is forbidden, check the discovery "+
+			"permissions of the controller service account: %w", gvk, err)
 	default:
 		return false, fmt.Errorf("failed to detect API resource %s: %w", gvk, err)
 	}
@@ -211,7 +212,7 @@ func retryUntilDefinitive(backoff wait.Backoff, logger logr.Logger, probe func()
 	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		probed = true
-		if lastErr = probe(); lastErr == nil || isResourceAbsent(lastErr) {
+		if lastErr = probe(); lastErr == nil || isDefinitive(lastErr) {
 			return true, nil
 		}
 		logger.Info("discovery request failed, retrying", "error", lastErr)
@@ -225,15 +226,16 @@ func retryUntilDefinitive(backoff wait.Backoff, logger logr.Logger, probe func()
 	return lastErr
 }
 
-// isResourceAbsent reports whether err definitively means the group/version is
-// not usable, as opposed to discovery having failed to reach a conclusion.
-func isResourceAbsent(err error) bool {
+// isDefinitive reports whether err settles the discovery request, so that
+// retrying it cannot change the outcome. Only the caller decides what a
+// definitive failure means: NotFound is absence, Forbidden is a misconfiguration.
+func isDefinitive(err error) bool {
 	switch {
 	// Discovery of a group/version that is not installed answers 404.
 	case apierrors.IsNotFound(err):
 		return true
-	// RBAC forbids discovery: the resource is not usable by this controller and
-	// waiting will not change that.
+	// RBAC forbids discovery: waiting will not change that, but it says nothing
+	// about whether the resource is served.
 	case apierrors.IsForbidden(err):
 		return true
 	// Connection refused, timeouts, EOF, 5xx, throttling: the API server may

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -18,12 +18,20 @@
 package utils
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -31,22 +39,81 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/types"
 )
 
-// HasAPIResource checks if a specific API resource is available in the current cluster.
-// It uses the Discovery API to query the cluster's available resources and returns true
-// if the resource is found, false otherwise.
-func HasAPIResource(mgr ctrl.Manager, obj client.Object) bool {
+const (
+	// A discovery request that gives no definitive answer is retried a few times
+	// to absorb short blips. A longer outage is reported to the caller instead:
+	// it is not this function's job to decide how long to wait for the API server.
+	discoveryRetryInitialInterval = 500 * time.Millisecond
+	discoveryRetrySteps           = 5 // ~7.5s, up to ~8.3s with jitter
+
+	// The startup wait for the API server is deliberately finite. The health
+	// probe endpoint is only served once mgr.Start runs, so a pod still waiting
+	// here fails its liveness probe and is killed anyway; giving up with an
+	// explicit error and letting the pod restart says more in the logs than
+	// being killed mid-wait. Longer outages are absorbed by the restart backoff.
+	apiServerWaitInitialInterval = 1 * time.Second
+	apiServerWaitSteps           = 6 // ~31s, up to ~34s with jitter
+
+	backoffFactor = 2
+	backoffJitter = 0.1
+)
+
+// Neither backoff sets Cap: wait.Backoff zeroes the remaining steps as soon as
+// the capped interval is reached, which would silently cut the retries short.
+
+func discoveryBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: discoveryRetryInitialInterval,
+		Factor:   backoffFactor,
+		Jitter:   backoffJitter,
+		Steps:    discoveryRetrySteps,
+	}
+}
+
+func apiServerWaitBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: apiServerWaitInitialInterval,
+		Factor:   backoffFactor,
+		Jitter:   backoffJitter,
+		Steps:    apiServerWaitSteps,
+	}
+}
+
+// HasAPIResource reports whether the API resource of obj is served by the cluster.
+//
+// An error is returned when discovery cannot produce a definitive answer, for
+// instance because the API server is unreachable. Callers must not fall back to
+// "resource absent" in that case: detection runs once at startup and gates field
+// index, controller and readiness registration, so a temporary API server outage
+// would otherwise leave the controller permanently degraded until it is
+// restarted.
+func HasAPIResource(mgr ctrl.Manager, obj client.Object) (bool, error) {
 	return HasAPIResourceWithLogger(mgr, obj, ctrl.Log.WithName("api-detection"))
 }
 
 // HasAPIResourceWithLogger is the same as HasAPIResource but accepts a custom logger
 // for more detailed debugging information.
-func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.Logger) bool {
+func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.Logger) (bool, error) {
 	gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
 	if err != nil {
-		logger.Info("cannot derive GVK from scheme", "error", err)
-		return false
+		return false, fmt.Errorf("cannot derive GVK from scheme: %w", err)
 	}
 
+	// Create discovery client
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+	if err != nil {
+		return false, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	return hasAPIResource(discoveryClient, gvk, discoveryBackoff(), logger)
+}
+
+func hasAPIResource(
+	discoveryClient discovery.DiscoveryInterface,
+	gvk schema.GroupVersionKind,
+	backoff wait.Backoff,
+	logger logr.Logger,
+) (bool, error) {
 	groupVersion := gvk.GroupVersion().String()
 
 	logger = logger.WithValues(
@@ -56,29 +123,124 @@ func HasAPIResourceWithLogger(mgr ctrl.Manager, obj client.Object, logger logr.L
 		"groupVersion", groupVersion,
 	)
 
-	// Create discovery client
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
-	if err != nil {
-		logger.Info("failed to create discovery client", "error", err)
-		return false
-	}
-
 	// Query server resources for the specific group/version
-	apiResources, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
-	if err != nil {
+	var apiResources *metav1.APIResourceList
+	err := retryUntilDefinitive(backoff, logger, func() error {
+		var err error
+		apiResources, err = discoveryClient.ServerResourcesForGroupVersion(groupVersion)
+		return err
+	})
+	switch {
+	case err == nil:
+	case apierrors.IsNotFound(err):
 		logger.Info("group/version not available in cluster", "error", err)
-		return false
+		return false, nil
+	case apierrors.IsForbidden(err):
+		// Definitive, but a misconfiguration rather than an absent CRD: log loudly
+		// so it is not mistaken for "the CRD was never installed".
+		logger.Error(err, "discovery is forbidden, treating the API resource as not installed; "+
+			"check the discovery permissions of the controller service account")
+		return false, nil
+	default:
+		return false, fmt.Errorf("failed to detect API resource %s: %w", gvk, err)
 	}
 
 	// Check if the specific kind exists in the resource list
 	for _, res := range apiResources.APIResources {
 		if res.Kind == gvk.Kind {
-			return true
+			return true, nil
 		}
 	}
 
 	logger.Info("API resource kind not found in group/version")
-	return false
+	return false, nil
+}
+
+// WaitForAPIServer blocks until the API server answers a discovery request, ctx
+// is done, or the wait budget is exhausted.
+//
+// Capability detection (field indexes, optional CRDs, ReferenceGrant support) is
+// decided once at startup and cannot be revised afterwards, so it must not run
+// against an unreachable API server.
+func WaitForAPIServer(ctx context.Context, cfg *rest.Config, logger logr.Logger) error {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	return waitForAPIServer(ctx, func() error {
+		_, err := discoveryClient.ServerVersion()
+		return err
+	}, apiServerWaitBackoff(), logger)
+}
+
+func waitForAPIServer(ctx context.Context, probe func() error, backoff wait.Backoff, logger logr.Logger) error {
+	var lastErr error
+	if err := wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
+		if lastErr = probe(); !apiServerAnswered(lastErr) {
+			logger.Info("waiting for the Kubernetes API server to become reachable", "error", lastErr)
+			return false, nil
+		}
+		if lastErr != nil {
+			logger.Info("the Kubernetes API server rejected the probe but is reachable, continuing", "error", lastErr)
+		}
+		return true, nil
+	}); err != nil {
+		// ExponentialBackoffWithContext only ever returns ctx.Err() or its own
+		// interrupted error, so this tells cancellation and an exhausted budget
+		// apart without racing against ctx.
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && lastErr != nil {
+			err = lastErr
+		}
+		return fmt.Errorf("give up waiting for the Kubernetes API server: %w", err)
+	}
+	return nil
+}
+
+// apiServerAnswered reports whether err still proves the API server responded.
+// An authn/authz rejection is an answer: a hardened cluster may not grant the
+// controller's service account access to the probed endpoint, and that is no
+// reason to hold up startup.
+func apiServerAnswered(err error) bool {
+	return err == nil || apierrors.IsUnauthorized(err) || apierrors.IsForbidden(err)
+}
+
+// retryUntilDefinitive runs probe until it returns nil or a definitive answer,
+// and reports the last failure once the retry budget is exhausted.
+func retryUntilDefinitive(backoff wait.Backoff, logger logr.Logger, probe func() error) error {
+	var probed bool
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		probed = true
+		if lastErr = probe(); lastErr == nil || isResourceAbsent(lastErr) {
+			return true, nil
+		}
+		logger.Info("discovery request failed, retrying", "error", lastErr)
+		return false, nil
+	})
+	if !probed {
+		// A backoff with no steps left never runs the condition. Reporting nil
+		// here would be read as "the resource is present" by every caller.
+		return fmt.Errorf("discovery was never attempted: %w", err)
+	}
+	return lastErr
+}
+
+// isResourceAbsent reports whether err definitively means the group/version is
+// not usable, as opposed to discovery having failed to reach a conclusion.
+func isResourceAbsent(err error) bool {
+	switch {
+	// Discovery of a group/version that is not installed answers 404.
+	case apierrors.IsNotFound(err):
+		return true
+	// RBAC forbids discovery: the resource is not usable by this controller and
+	// waiting will not change that.
+	case apierrors.IsForbidden(err):
+		return true
+	// Connection refused, timeouts, EOF, 5xx, throttling: the API server may
+	// answer differently once it is reachable again, so no conclusion yet.
+	default:
+		return false
+	}
 }
 
 func FormatGVK(obj client.Object) string {

--- a/pkg/utils/cluster_test.go
+++ b/pkg/utils/cluster_test.go
@@ -88,12 +88,12 @@ func TestBackoffsUseAllTheirSteps(t *testing.T) {
 	}
 }
 
-func TestIsResourceAbsent(t *testing.T) {
+func TestIsDefinitive(t *testing.T) {
 	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
 	tests := []struct {
-		name   string
-		err    error
-		absent bool
+		name       string
+		err        error
+		definitive bool
 	}{
 		// Definitive: the group/version is genuinely not served.
 		{"not found", apierrors.NewNotFound(gr, "tcproutes"), true},
@@ -109,7 +109,7 @@ func TestIsResourceAbsent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.absent, isResourceAbsent(tt.err))
+			assert.Equal(t, tt.definitive, isDefinitive(tt.err))
 		})
 	}
 }
@@ -127,7 +127,7 @@ func TestRetryUntilDefinitive_ReportsIndeterminateFailure(t *testing.T) {
 
 	err := retryUntilDefinitive(fastBackoff(3), logr.Discard(), probe)
 	require.Error(t, err, "an unreachable API server must not be reported as a definitive answer")
-	assert.False(t, isResourceAbsent(err))
+	assert.False(t, isDefinitive(err))
 	assert.Equal(t, 3, calls, "the whole retry budget must be used")
 }
 
@@ -156,7 +156,7 @@ func TestRetryUntilDefinitive_DefinitiveAbsent(t *testing.T) {
 	}
 
 	err := retryUntilDefinitive(fastBackoff(5), logr.Discard(), probe)
-	assert.True(t, isResourceAbsent(err))
+	assert.True(t, isDefinitive(err))
 	assert.Equal(t, 1, calls, "a definitive NotFound must not be retried")
 }
 
@@ -173,7 +173,7 @@ func TestRetryUntilDefinitive_NeverProbed(t *testing.T) {
 	err := retryUntilDefinitive(wait.Backoff{Steps: 0}, logr.Discard(), probe)
 	require.Error(t, err)
 	assert.Zero(t, calls)
-	assert.False(t, isResourceAbsent(err), "an unattempted probe must not resolve to absent either")
+	assert.False(t, isDefinitive(err), "an unattempted probe must not look like a definitive answer either")
 }
 
 func TestWaitForAPIServer_RetriesUntilReachable(t *testing.T) {
@@ -297,10 +297,15 @@ func TestHasAPIResource(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// Forbidden is definitive but proves nothing about the resource: the
+			// CRD may well be served and only discovery denied. Resolving it to
+			// "absent" would permanently skip the controller, so it must abort
+			// startup and point at the RBAC instead.
 			name: "discovery forbidden",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusForbidden)
 			},
+			wantErr: true,
 		},
 	}
 

--- a/pkg/utils/cluster_test.go
+++ b/pkg/utils/cluster_test.go
@@ -1,0 +1,319 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// fastBackoff keeps the tests quick while preserving the shape of the
+// production backoffs (a growing interval over a fixed number of steps).
+func fastBackoff(steps int) wait.Backoff {
+	return wait.Backoff{Duration: time.Millisecond, Factor: backoffFactor, Jitter: backoffJitter, Steps: steps}
+}
+
+// declaredBudget is how long a backoff sleeps in total before jitter, i.e. the
+// sum of the intervals between its attempts.
+func declaredBudget(backoff wait.Backoff) time.Duration {
+	var total, interval time.Duration = 0, backoff.Duration
+	for i := 0; i < backoff.Steps-1; i++ {
+		total += interval
+		interval = time.Duration(float64(interval) * backoff.Factor)
+	}
+	return total
+}
+
+// countingBackoff reports how many times a backoff actually runs its condition.
+func countAttempts(backoff wait.Backoff) int {
+	var attempts int
+	_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		attempts++
+		return false, nil
+	})
+	return attempts
+}
+
+// TestBackoffsUseAllTheirSteps guards against a subtle wait.Backoff behavior:
+// setting Cap zeroes the remaining steps as soon as the capped interval is
+// reached, silently cutting the retries short. Both backoffs must run every
+// step they declare.
+func TestBackoffsUseAllTheirSteps(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		backoff wait.Backoff
+		steps   int
+		budget  time.Duration // as documented next to the constants
+	}{
+		{"discovery", discoveryBackoff(), discoveryRetrySteps, 7500 * time.Millisecond},
+		{"apiServerWait", apiServerWaitBackoff(), apiServerWaitSteps, 31 * time.Second},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Zero(t, tt.backoff.Cap, "Cap truncates the retries, see wait.delay()")
+			assert.Equal(t, tt.budget, declaredBudget(tt.backoff), "the documented budget must match the backoff")
+
+			b := tt.backoff
+			b.Duration = time.Microsecond // keep the test fast, preserve the shape
+			assert.Equal(t, tt.steps, countAttempts(b))
+		})
+	}
+}
+
+func TestIsResourceAbsent(t *testing.T) {
+	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
+	tests := []struct {
+		name   string
+		err    error
+		absent bool
+	}{
+		// Definitive: the group/version is genuinely not served.
+		{"not found", apierrors.NewNotFound(gr, "tcproutes"), true},
+		// Definitive: RBAC will not self-heal by waiting.
+		{"forbidden", apierrors.NewForbidden(gr, "tcproutes", errors.New("nope")), true},
+		// Indeterminate: the API server is temporarily unreachable or overloaded.
+		{"connection refused", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, false},
+		{"service unavailable", apierrors.NewServiceUnavailable("apiserver is starting up"), false},
+		{"server timeout", apierrors.NewServerTimeout(gr, "get", 1), false},
+		{"too many requests", apierrors.NewTooManyRequestsError("slow down"), false},
+		{"internal error", apierrors.NewInternalError(errors.New("boom")), false},
+		{"generic transport error", errors.New("EOF"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.absent, isResourceAbsent(tt.err))
+		})
+	}
+}
+
+// TestRetryUntilDefinitive_ReportsIndeterminateFailure is the core regression
+// test for #2734: a discovery failure that gives no definitive answer must
+// surface as an error so the caller aborts startup, instead of collapsing into
+// "resource absent" and permanently skipping the field index and its controller.
+func TestRetryUntilDefinitive_ReportsIndeterminateFailure(t *testing.T) {
+	var calls int
+	probe := func() error {
+		calls++
+		return apierrors.NewServiceUnavailable("apiserver not ready")
+	}
+
+	err := retryUntilDefinitive(fastBackoff(3), logr.Discard(), probe)
+	require.Error(t, err, "an unreachable API server must not be reported as a definitive answer")
+	assert.False(t, isResourceAbsent(err))
+	assert.Equal(t, 3, calls, "the whole retry budget must be used")
+}
+
+func TestRetryUntilDefinitive_TransientThenSuccess(t *testing.T) {
+	var calls int
+	probe := func() error {
+		calls++
+		if calls < 3 {
+			return apierrors.NewServiceUnavailable("apiserver not ready")
+		}
+		return nil
+	}
+
+	require.NoError(t, retryUntilDefinitive(fastBackoff(5), logr.Discard(), probe))
+	assert.Equal(t, 3, calls, "an indeterminate failure must be retried, not given up on")
+}
+
+// TestRetryUntilDefinitive_DefinitiveAbsent ensures a genuinely absent CRD is
+// answered immediately without retrying, preserving optional-CRD support.
+func TestRetryUntilDefinitive_DefinitiveAbsent(t *testing.T) {
+	gr := schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "tcproutes"}
+	var calls int
+	probe := func() error {
+		calls++
+		return apierrors.NewNotFound(gr, "tcproutes")
+	}
+
+	err := retryUntilDefinitive(fastBackoff(5), logr.Discard(), probe)
+	assert.True(t, isResourceAbsent(err))
+	assert.Equal(t, 1, calls, "a definitive NotFound must not be retried")
+}
+
+// TestRetryUntilDefinitive_NeverProbed guards the caller's assumption that a
+// nil error means "the probe succeeded": a backoff with no steps left never runs
+// the condition, and reporting nil there would be read as "resource present".
+func TestRetryUntilDefinitive_NeverProbed(t *testing.T) {
+	var calls int
+	probe := func() error {
+		calls++
+		return nil
+	}
+
+	err := retryUntilDefinitive(wait.Backoff{Steps: 0}, logr.Discard(), probe)
+	require.Error(t, err)
+	assert.Zero(t, calls)
+	assert.False(t, isResourceAbsent(err), "an unattempted probe must not resolve to absent either")
+}
+
+func TestWaitForAPIServer_RetriesUntilReachable(t *testing.T) {
+	var calls int
+	probe := func() error {
+		calls++
+		if calls < 3 {
+			return &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		}
+		return nil
+	}
+
+	require.NoError(t, waitForAPIServer(context.Background(), probe, fastBackoff(6), logr.Discard()))
+	assert.Equal(t, 3, calls)
+}
+
+// TestWaitForAPIServer_AuthRejectionIsReachable covers a hardened cluster that
+// does not grant the controller access to the probed endpoint: the API server
+// answered, so startup must proceed instead of stalling until the budget runs
+// out and then failing on a perfectly healthy cluster.
+func TestWaitForAPIServer_AuthRejectionIsReachable(t *testing.T) {
+	for name, probeErr := range map[string]error{
+		"unauthorized": apierrors.NewUnauthorized("no token"),
+		"forbidden":    apierrors.NewForbidden(schema.GroupResource{}, "", errors.New("nope")),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var calls int
+			probe := func() error {
+				calls++
+				return probeErr
+			}
+			require.NoError(t, waitForAPIServer(context.Background(), probe, fastBackoff(5), logr.Discard()))
+			assert.Equal(t, 1, calls, "an answer, even a rejection, must not be retried")
+		})
+	}
+}
+
+func TestWaitForAPIServer_GivesUpWithTheLastError(t *testing.T) {
+	probe := func() error { return apierrors.NewServiceUnavailable("apiserver not ready") }
+
+	err := waitForAPIServer(context.Background(), probe, fastBackoff(3), logr.Discard())
+	require.Error(t, err)
+	assert.True(t, apierrors.IsServiceUnavailable(errors.Unwrap(err)), "the last probe error must be reported, got %v", err)
+}
+
+// TestWaitForAPIServer_HonorsContext ensures the wait is interrupted mid-flight,
+// so a shutdown signal is not ignored while the API server is unreachable.
+func TestWaitForAPIServer_HonorsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int
+	probe := func() error {
+		if calls++; calls == 2 {
+			cancel()
+		}
+		return &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	}
+
+	// A budget far larger than the number of attempts the test expects: the wait
+	// must end because ctx was cancelled, not because it ran out of steps.
+	err := waitForAPIServer(ctx, probe, fastBackoff(100), logr.Discard())
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 2, calls, "the probe must stop being called once ctx is cancelled")
+}
+
+// newDiscoveryClient serves discovery responses from handler.
+func newDiscoveryClient(t *testing.T, handler http.HandlerFunc) discovery.DiscoveryInterface {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c, err := discovery.NewDiscoveryClientForConfig(&rest.Config{Host: srv.URL})
+	require.NoError(t, err)
+	return c
+}
+
+// TestHasAPIResource covers the contract every caller depends on, against a real
+// discovery client rather than a fake: only a definitive answer may resolve to
+// "absent", everything else must be an error.
+func TestHasAPIResource(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
+
+	tests := []struct {
+		name      string
+		handler   http.HandlerFunc
+		wantFound bool
+		wantErr   bool
+	}{
+		{
+			name: "kind served",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1alpha2",` +
+					`"resources":[{"name":"tcproutes","kind":"TCPRoute"}]}`))
+			},
+			wantFound: true,
+		},
+		{
+			name: "group/version served but kind missing",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1alpha2",` +
+					`"resources":[{"name":"udproutes","kind":"UDPRoute"}]}`))
+			},
+		},
+		{
+			// What a real API server returns for a group/version that is not
+			// installed: a plain-text 404, not a Status object.
+			name: "group/version not installed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.NotFound(w, nil)
+			},
+		},
+		{
+			// The #2734 scenario: the API server cannot answer. This must not be
+			// reported as "the CRD is not installed".
+			name: "api server unavailable",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			},
+			wantErr: true,
+		},
+		{
+			name: "discovery forbidden",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found, err := hasAPIResource(newDiscoveryClient(t, tt.handler), gvk, fastBackoff(2), logr.Discard())
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.False(t, found)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFound, found)
+		})
+	}
+}


### PR DESCRIPTION
Port of apache/apisix-ingress-controller#2817 — fixes apache/apisix-ingress-controller#2734.

### Problem

After a control-plane failover (kube-apiserver unreachable while the controller was starting up), every reconcile failed forever with `Index with name field:serviceRefs/secretRefs/ingressClassParametersRef does not exist` until the pod was restarted manually.

`HasAPIResource` returned `false` on *any* discovery error — indistinguishable from "the CRD is genuinely not installed". Detection runs once at startup and gates field index, controller and readiness registration, so an API server that was unreachable at that instant classified everything as absent. Informers reconnected on their own once it came back, so reconciles ran, but every `List` with a field selector failed permanently.

**This repository is affected more broadly than upstream.** The same call also decides:
- `supportsEndpointSlice` in the ApisixRoute / Ingress / HTTPRoute / GatewayProxy reconcilers — a transient outage permanently downgrades endpoint discovery to Endpoints;
- the IngressClass v1 vs v1beta1 choice in `setupControllers` and `registerV2ForReadinessGVK` — a transient outage permanently falls back to v1beta1 on a v1 cluster.

The ReferenceGrant detection in `run.go` had its own variant of the defect: a transient `RESTMapper.KindsFor` error set the process-wide `enableReferenceGrant` to `false`, which makes `checkReferenceGrant` reject every cross-namespace reference and skips the ReferenceGrant watches.

### Fix

1. Wait for the API server to answer a discovery request before any capability detection runs (`utils.WaitForAPIServer`). These are one-shot decisions that cannot be revised later, so they must not be made against a dead API server. The wait is bounded (~31s) because the health probe endpoint is only served once `mgr.Start` runs — a pod still waiting fails its liveness probe anyway, and an explicit error says more in the logs than being killed mid-wait.
2. `ctrl.SetupSignalHandler` moves to the start of `Run` so the wait is interruptible, and setup checks the signal context between phases so a shutdown signal is not swallowed until `mgr.Start`.
3. `HasAPIResource` returns `(bool, error)`. Only a 404 on the group/version (not installed) or a Forbidden (RBAC, will not resolve by waiting) resolves to "absent"; anything else — connection refused, timeout, EOF, 5xx, throttling — is retried briefly and then surfaced as an error that aborts setup. All call sites propagate it, so a controller, a field index, EndpointSlice support or the IngressClass version can no longer be silently downgraded. A Forbidden is logged at error level with a distinct message so it is not misread as a missing CRD.
4. An authn/authz rejection of the reachability probe counts as the API server having answered: a hardened cluster may not grant the controller access to the probed endpoint, and that is no reason to hold up startup.
5. ReferenceGrant support is detected through the same path, and skipped entirely when Gateway API is disabled.

**What an operator sees.** The failure mode changes from "the pod is Running but half of it is permanently dead" to "the pod exits with an explicit error and is restarted". If the API server is still unreachable after the wait budget, `Run` returns e.g. `give up waiting for the Kubernetes API server: dial tcp ...: connect: connection refused`, the process exits non-zero and the kubelet restarts it with the usual CrashLoopBackOff. Retrying does not stop — it moves from an in-process loop to the pod restart loop, which is where Kubernetes wants it.

Behavior for a genuinely absent optional CRD is unchanged: detection returns `false` immediately, without retrying, and the corresponding indexer/controller/watch is skipped as before.

Registering the indexes unconditionally is not an option: `IndexField` eagerly resolves the GVK through the RESTMapper, which errors when the CRD really is absent.

### Tests

`pkg/utils/cluster_test.go` covers the error classification, the detection contract against a real discovery client driven by `httptest` (kind served / kind missing / group-version absent / API server unavailable / forbidden), the retry budgets, and that the wait is interruptible mid-flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by retrying temporary Kubernetes API and resource-discovery failures.
  * Controller setup now stops and reports errors when required API checks fail.
  * Optional controllers and watches are enabled only when their APIs are available.
  * Startup and shutdown handling now responds more promptly to API availability and termination signals.

* **Tests**
  * Added coverage for API discovery, retries, backoff behavior, readiness checks, and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->