### PR TITLE
fix(httproute): read appProtocol for ExternalName services

### DIFF
--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -424,6 +424,12 @@ func (t *Translator) translateBackendRef(tctx *provider.TranslateContext, ref ga
 		port := 80
 		if ref.Port != nil {
 			port = int(*ref.Port)
+			for _, p := range service.Spec.Ports {
+				if int(p.Port) == port {
+					protocol = ptr.Deref(p.AppProtocol, "")
+					break
+				}
+			}
 		}
 		return adctypes.UpstreamNodes{
 			{

--- a/internal/adc/translator/httproute_test.go
+++ b/internal/adc/translator/httproute_test.go
@@ -150,6 +150,104 @@ func TestTranslateHTTPRouteUpstreamScheme(t *testing.T) {
 	}
 }
 
+func TestTranslateHTTPRouteExternalNameAppProtocol(t *testing.T) {
+	tests := []struct {
+		name          string
+		appProtocol   string
+		wantScheme    string
+		wantWebsocket *bool
+	}{
+		{
+			name:          "ExternalName with wss appProtocol",
+			appProtocol:   internaltypes.AppProtocolWSS,
+			wantScheme:    apiv2.SchemeHTTPS,
+			wantWebsocket: ptr.To(true),
+		},
+		{
+			name:          "ExternalName with ws appProtocol",
+			appProtocol:   internaltypes.AppProtocolWS,
+			wantScheme:    apiv2.SchemeHTTP,
+			wantWebsocket: ptr.To(true),
+		},
+		{
+			name:        "ExternalName with http appProtocol",
+			appProtocol: internaltypes.AppProtocolHTTP,
+			wantScheme:  apiv2.SchemeHTTP,
+		},
+		{
+			// An unset appProtocol falls through to the explicit http default
+			// applied to every upstream.
+			name:        "ExternalName without appProtocol",
+			appProtocol: "",
+			wantScheme:  apiv2.SchemeHTTP,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translator := NewTranslator(logr.Discard(), "")
+			tctx := provider.NewDefaultTranslateContext(context.Background())
+
+			const (
+				namespace   = "default"
+				serviceName = "external-backend"
+				portNumber  = 5000
+			)
+
+			var appProtocol *string
+			if tt.appProtocol != "" {
+				appProtocol = ptr.To(tt.appProtocol)
+			}
+
+			serviceKey := types.NamespacedName{Namespace: namespace, Name: serviceName}
+			tctx.Services[serviceKey] = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Type:         corev1.ServiceTypeExternalName,
+					ExternalName: "example.com",
+					Ports: []corev1.ServicePort{{
+						Name:        "web",
+						Port:        portNumber,
+						AppProtocol: appProtocol,
+					}},
+				},
+			}
+
+			route := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo",
+					Namespace: namespace,
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{{
+						BackendRefs: []gatewayv1.HTTPBackendRef{{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(serviceName),
+									Port: ptr.To(gatewayv1.PortNumber(portNumber)),
+								},
+							},
+						}},
+					}},
+				},
+			}
+
+			result, err := translator.TranslateHTTPRoute(tctx, route)
+			require.NoError(t, err)
+			require.Len(t, result.Services, 1)
+			require.NotNil(t, result.Services[0].Upstream)
+			require.Len(t, result.Services[0].Routes, 1)
+
+			assert.Equal(t, tt.wantScheme, result.Services[0].Upstream.Scheme)
+			assert.Equal(t, "example.com", result.Services[0].Upstream.Nodes[0].Host)
+			assert.Equal(t, tt.wantWebsocket, result.Services[0].Routes[0].EnableWebsocket)
+		})
+	}
+}
+
 func TestAttachBackendTrafficPolicyHealthCheck(t *testing.T) {
 	trueVal := true
 	falseVal := false


### PR DESCRIPTION

### What this PR does / why we need it

When an HTTPRoute targets an `ExternalName` Service, `translateBackendRef` returned before the port lookup that reads `appProtocol`, so `kubernetes.io/ws` / `wss` and the derived upstream scheme were lost — websocket upgrades to external backends had their `connection: upgrade` header stripped. Cluster-IP Services were unaffected.

The fix reads `AppProtocol` from the matching port entry in the ExternalName branch. `translateBackendRef` is the shared helper behind HTTPRoute, GRPCRoute, TLSRoute and ApisixRoute, so all of them are covered. The Ingress path already handled this correctly and is untouched.

### EE-specific note

The upstream test asserts an empty scheme when `appProtocol` is unset; here it asserts `http`, because this repo applies an explicit `cmp.Or(upstream.Scheme, apiv2.SchemeHTTP)` default (`internal/adc/translator/httproute.go`). Adjusted accordingly.

### Verification

```
go test ./internal/adc/translator/    # PASS
golangci-lint run ./internal/adc/translator/...    # 0 issues
```
Reverting the `httproute.go` hunk makes all four new sub-tests fail, so the test genuinely covers the regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected protocol handling for routes targeting external-name services.
  * WebSocket and secure WebSocket protocols are now translated correctly, including appropriate WebSocket enablement.
  * Unspecified protocols now default to HTTP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->