### PR TITLE
fix: preserve ApisixUpstream health check type

### DIFF
--- a/internal/adc/translator/apisixupstream.go
+++ b/internal/adc/translator/apisixupstream.go
@@ -315,6 +315,7 @@ func translateUpstreamActiveHealthCheck(config *apiv2.ActiveHealthCheck) (*adc.U
 		config.Type = apiv2.HealthCheckHTTP
 	}
 
+	active.Type = config.Type
 	active.Timeout = int(config.Timeout.Seconds())
 	active.Port = config.Port
 	active.Concurrency = config.Concurrency
@@ -357,6 +358,7 @@ func translateUpstreamPassiveHealthCheck(config *apiv2.PassiveHealthCheck) *adc.
 		config.Type = apiv2.HealthCheckHTTP
 	}
 
+	passive.Type = config.Type
 	if config.Healthy != nil {
 		passive.Healthy.Successes = config.Healthy.Successes
 		passive.Healthy.HTTPStatuses = config.Healthy.HTTPCodes

--- a/internal/adc/translator/apisixupstream_test.go
+++ b/internal/adc/translator/apisixupstream_test.go
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package translator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
+)
+
+func TestTranslateUpstreamHealthCheckPreservesType(t *testing.T) {
+	tests := []struct {
+		name      string
+		typeValue string
+		expected  string
+	}{
+		{name: "default", expected: apiv2.HealthCheckHTTP},
+		{name: "http", typeValue: apiv2.HealthCheckHTTP, expected: apiv2.HealthCheckHTTP},
+		{name: "https", typeValue: apiv2.HealthCheckHTTPS, expected: apiv2.HealthCheckHTTPS},
+		{name: "tcp", typeValue: apiv2.HealthCheckTCP, expected: apiv2.HealthCheckTCP},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			active, err := translateUpstreamActiveHealthCheck(&apiv2.ActiveHealthCheck{Type: test.typeValue})
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, active.Type)
+
+			passive := translateUpstreamPassiveHealthCheck(&apiv2.PassiveHealthCheck{Type: test.typeValue})
+			assert.Equal(t, test.expected, passive.Type)
+		})
+	}
+}

--- a/test/e2e/crds/v2/upstream.go
+++ b/test/e2e/crds/v2/upstream.go
@@ -65,7 +65,7 @@ spec:
   retries: 1
   healthCheck:
     active:
-      type: http
+      type: tcp
       httpPath: /ip
       healthy:
         httpCodes: [200]
@@ -74,6 +74,7 @@ spec:
         httpFailures: 2
         interval: 1s
     passive:
+      type: https
       healthy:
         httpCodes: [200]
       unhealthy:
@@ -115,6 +116,7 @@ spec:
 				g.Expect(ups[0].Nodes).To(HaveLen(3), "the number of upstream nodes")
 				g.Expect(ups[0].Checks).ToNot(BeNil(), "the healthcheck configuration")
 				g.Expect(ups[0].Checks.Active).ToNot(BeNil(), "the active healthcheck configuration")
+				g.Expect(ups[0].Checks.Active.Type).To(Equal(apiv2.HealthCheckTCP), "the active healthcheck type")
 				g.Expect(ups[0].Checks.Active.Healthy).ToNot(BeNil(), "the active healthy configuration")
 				g.Expect(ups[0].Checks.Active.Unhealthy).ToNot(BeNil(), "the active unhealthy configuration")
 				g.Expect(ups[0].Checks.Active.Healthy.Interval).To(Equal(1), "the healthy interval")
@@ -122,6 +124,7 @@ spec:
 				g.Expect(ups[0].Checks.Active.Unhealthy.Interval).To(Equal(1), "the unhealthy interval")
 				g.Expect(ups[0].Checks.Active.Unhealthy.HTTPFailures).To(Equal(2), "the unhealthy http failures")
 				g.Expect(ups[0].Checks.Passive).ToNot(BeNil(), "the passive healthcheck configuration")
+				g.Expect(ups[0].Checks.Passive.Type).To(Equal(apiv2.HealthCheckHTTPS), "the passive healthcheck type")
 				g.Expect(ups[0].Checks.Passive.Healthy).ToNot(BeNil(), "the passive healthy configuration")
 				g.Expect(ups[0].Checks.Passive.Unhealthy).ToNot(BeNil(), "the passive unhealthy configuration")
 				g.Expect(ups[0].Checks.Passive.Healthy.HTTPStatuses).To(Equal([]int{200}), "the passive healthy http status")


### PR DESCRIPTION
Sync of apache/apisix-ingress-controller#2828, originally authored by @xiaocanglan1.

### What this PR does / why we need it

`translateUpstreamActiveHealthCheck` / `translateUpstreamPassiveHealthCheck` defaulted `config.Type` to `http` but never copied it into the ADC upstream model, so an explicit `https` or `tcp` health check type on an `ApisixUpstream` was silently dropped. The data plane then fell back to HTTP probes — which means plain HTTP probes sent to HTTPS upstream ports.

Both `adc.UpstreamActiveHealthCheck.Type` and `adc.UpstreamPassiveHealthCheck.Type` already exist in `api/adc/types.go`; they were simply never populated.

### Changes

- copy the resolved type into the ADC model for both active and passive checks
- new unit test covering default / http / https / tcp
- e2e `ApisixUpstream` contract extended to use non-default types (`active: tcp`, `passive: https`) and assert them in the generated upstream configuration

### Verification

```
go test ./internal/adc/translator/    # PASS
go vet ./test/e2e/crds/v2/            # clean
golangci-lint run ./internal/adc/translator/...    # 0 issues
```
Reverting the `apisixupstream.go` hunk makes every new sub-test fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved configured active and passive health-check types when translating upstream configurations.
  * Applied the default HTTP type when no health-check type is specified.

* **Tests**
  * Added coverage for default, HTTP, HTTPS, and TCP health-check types.
  * Expanded end-to-end validation of resolved active and passive health-check types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->