### PR TITLE
fix: normalize hosts and SNIs so uppercase hostnames stay routable

### DIFF
--- a/internal/adc/translator/apisixroute.go
+++ b/internal/adc/translator/apisixroute.go
@@ -35,6 +35,7 @@ import (
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/label"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
+	sslutils "github.com/apache/apisix-ingress-controller/internal/ssl"
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 	"github.com/apache/apisix-ingress-controller/internal/utils"
 	"github.com/apache/apisix-ingress-controller/pkg/id"
@@ -308,7 +309,7 @@ func (t *Translator) buildService(ar *apiv2.ApisixRoute, rule apiv2.ApisixRouteH
 	service.Name = adc.ComposeServiceNameWithRule(ar.Namespace, ar.Name, fmt.Sprintf("%d", ruleIndex))
 	service.ID = id.GenID(service.Name)
 	service.Labels = label.GenLabel(ar)
-	service.Hosts = rule.Match.Hosts
+	service.Hosts = sslutils.NormalizeHosts(rule.Match.Hosts)
 	service.Upstream = adc.NewDefaultUpstream()
 	return service
 }

--- a/internal/adc/translator/apisixroute_test.go
+++ b/internal/adc/translator/apisixroute_test.go
@@ -91,6 +91,35 @@ func TestBuildService_HostsSet(t *testing.T) {
 	assert.Equal(t, []string{"example.com", "foo.com"}, service.Hosts)
 }
 
+func TestBuildService_HostsLowercased(t *testing.T) {
+	translator := NewTranslator(logr.Discard(), "")
+
+	ar := &apiv2.ApisixRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "default",
+		},
+	}
+
+	rule := apiv2.ApisixRouteHTTP{
+		Name: "rule1",
+		Match: apiv2.ApisixRouteHTTPMatch{
+			Hosts: []string{"MixedCase.example.com", "*.UPPER.example.com", "mixedcase.example.com"},
+			Paths: []string{"/api/*"},
+		},
+	}
+
+	service := translator.buildService(ar, rule, 0)
+
+	// APISIX matches service hosts against nginx's $host, which is always lowercase,
+	// and does not normalize service-level hosts itself. Entries that collide once
+	// lowercased collapse: the APISIX service schema requires unique hosts.
+	assert.Equal(t, []string{"mixedcase.example.com", "*.upper.example.com"}, service.Hosts)
+
+	rule.Match.Hosts = nil
+	assert.Nil(t, translator.buildService(ar, rule, 0).Hosts)
+}
+
 func TestBuildRoute_MetadataLabelsDoNotOverwriteControllerLabels(t *testing.T) {
 	translator := NewTranslator(logr.Discard(), "")
 

--- a/internal/adc/translator/apisixtls.go
+++ b/internal/adc/translator/apisixtls.go
@@ -55,6 +55,7 @@ func (t *Translator) TranslateApisixTls(tctx *provider.TranslateContext, tls *ap
 	for i, host := range tls.Spec.Hosts {
 		snis[i] = string(host)
 	}
+	snis = sslutils.NormalizeHosts(snis)
 
 	// Create SSL object
 	ssl := &adctypes.SSL{

--- a/internal/adc/translator/gateway.go
+++ b/internal/adc/translator/gateway.go
@@ -271,6 +271,9 @@ func (t *Translator) translateSecret(tctx *provider.TranslateContext, listener g
 					}
 					sslObj.Snis = append(sslObj.Snis, hosts...)
 				}
+				// dedupGatewaySSLSNIs compares SNIs verbatim, so they have to be
+				// normalized before a collision can be recognised
+				sslObj.Snis = sslutils.NormalizeHosts(sslObj.Snis)
 				sslObj.Client = client
 				sslObj.ID = id.GenID(fmt.Sprintf("%s_%s_%d", adctypes.ComposeSSLName(internaltypes.KindGateway, obj.Namespace, obj.Name), listener.Name, refIndex))
 				t.Log.V(1).Info("generated ssl id", "ssl id", sslObj.ID, "secret", secretNN.String())

--- a/internal/adc/translator/grpcroute.go
+++ b/internal/adc/translator/grpcroute.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/controller/label"
 	"github.com/apache/apisix-ingress-controller/internal/id"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
+	sslutils "github.com/apache/apisix-ingress-controller/internal/ssl"
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 )
 
@@ -158,6 +159,9 @@ func (t *Translator) TranslateGRPCRoute(tctx *provider.TranslateContext, grpcRou
 			hosts = append(hosts, string(*listener.Hostname))
 		}
 	}
+	// the listener hostnames can repeat what the route already declares, and the APISIX
+	// service schema requires unique hosts
+	hosts = sslutils.NormalizeHosts(hosts)
 
 	rules := grpcRoute.Spec.Rules
 

--- a/internal/adc/translator/grpcroute_test.go
+++ b/internal/adc/translator/grpcroute_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
@@ -165,5 +166,38 @@ func TestTranslateGRPCRouteServerPortVarsByMode(t *testing.T) {
 				assert.Equal(t, tt.expected, got.Services[0].Routes[0].Vars)
 			}
 		})
+	}
+}
+
+func TestTranslateGRPCRoute_HostsDeduplicated(t *testing.T) {
+	tctx := provider.NewDefaultTranslateContext(context.Background())
+	tctx.Listeners = []gatewayv1.Listener{
+		{
+			Name:     "grpc",
+			Protocol: gatewayv1.HTTPProtocolType,
+			Port:     gatewayv1.PortNumber(80),
+			Hostname: ptr.To(gatewayv1.Hostname("example.com")),
+		},
+	}
+
+	grpcRoute := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			Hostnames: []gatewayv1.Hostname{"example.com"},
+			Rules:     []gatewayv1.GRPCRouteRule{{}},
+		},
+	}
+
+	translator := NewTranslator(logr.Discard(), config.ListenerPortMatchModeOff)
+	got, err := translator.TranslateGRPCRoute(tctx, grpcRoute)
+	assert.NoError(t, err)
+
+	// The listener hostname repeats what the route already declares. The APISIX
+	// service schema requires unique hosts, so the duplicate has to collapse.
+	if assert.Len(t, got.Services, 1) {
+		assert.Equal(t, []string{"example.com"}, got.Services[0].Hosts)
 	}
 }

--- a/internal/adc/translator/httproute.go
+++ b/internal/adc/translator/httproute.go
@@ -37,6 +37,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/controller/label"
 	"github.com/apache/apisix-ingress-controller/internal/id"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
+	sslutils "github.com/apache/apisix-ingress-controller/internal/ssl"
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 )
 
@@ -706,6 +707,7 @@ func (t *Translator) TranslateHTTPRoute(tctx *provider.TranslateContext, httpRou
 	for _, hostname := range httpRoute.Spec.Hostnames {
 		hosts = append(hosts, string(hostname))
 	}
+	hosts = sslutils.NormalizeHosts(hosts)
 
 	rules := httpRoute.Spec.Rules
 

--- a/internal/adc/translator/ingress.go
+++ b/internal/adc/translator/ingress.go
@@ -53,6 +53,7 @@ func (t *Translator) translateIngressTLS(namespace, name string, tlsIndex int, i
 		}
 		hosts = append(hosts, certHosts...)
 	}
+	hosts = sslutils.NormalizeHosts(hosts)
 	if len(hosts) == 0 {
 		return nil, fmt.Errorf("no hosts found in ingress TLS")
 	}
@@ -101,6 +102,7 @@ func (t *Translator) TranslateIngress(
 		if rule.Host != "" {
 			hosts = append(hosts, rule.Host)
 		}
+		hosts = sslutils.NormalizeHosts(hosts)
 
 		for j, path := range rule.HTTP.Paths {
 			index := fmt.Sprintf("%d-%d", i, j)

--- a/test/e2e/crds/v2/route.go
+++ b/test/e2e/crds/v2/route.go
@@ -183,6 +183,40 @@ spec:
 			It("Basic: with named service port and granularity service", func() {
 				test(apisixRouteSpecWithNameServiceAndGranularity)
 			})
+			It("Basic: with an uppercase host", func() {
+				const apisixRouteSpecWithUppercaseHost = `
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: default
+  namespace: %s
+spec:
+  ingressClassName: %s
+  http:
+  - name: rule0
+    match:
+      hosts:
+      - HTTPBIN.Example.com
+      paths:
+      - /get
+    backends:
+    - serviceName: httpbin-service-e2e-test
+      servicePort: 80
+`
+				By("apply ApisixRoute")
+				var apisixRoute apiv2.ApisixRoute
+				applier.MustApplyAPIv2(types.NamespacedName{Namespace: s.Namespace(), Name: "default"},
+					&apisixRoute, fmt.Sprintf(apisixRouteSpecWithUppercaseHost, s.Namespace(), s.Namespace()))
+
+				// APISIX matches hosts against nginx's $host, which is always lowercase,
+				// so the host has to be stored lowercase to be reachable at all.
+				request := func(host string) int {
+					return s.NewAPISIXClient().GET("/get").WithHost(host).Expect().Raw().StatusCode
+				}
+				By("verify the route is reachable regardless of the Host header case")
+				Eventually(request).WithArguments("HTTPBIN.Example.com").WithTimeout(20 * time.Second).ProbeEvery(time.Second).Should(Equal(http.StatusOK))
+				Expect(request("httpbin.example.com")).Should(Equal(http.StatusOK))
+			})
 		})
 
 		It("Test plugins in ApisixRoute", func() {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

- [x] Bugfix

### What this PR does / why we need it:

Sync of apache/apisix-ingress-controller#2837.

An `ApisixRoute` whose `match.hosts` contains an uppercase character is silently unroutable: every request for that host returns 404, on every path and for every casing of the request `Host` header.

Route matching runs against `$host`, which nginx always lowercases (`ngx_http_validate_host()`). APISIX normalizes the route object to match, in `apisix/router.lua`:

```lua
if route.value.host then
    route.value.host = str_lower(route.value.host)
elseif route.value.hosts then
    for i, v in ipairs(route.value.hosts) do
        route.value.hosts[i] = str_lower(v)
    end
end
```

`apisix/http/service.lua` has no equivalent, so `service.hosts` is stored verbatim, and the default `radixtree_host_uri` router keys its host buckets on the raw reversed host string:

```lua
for i, host in ipairs(hosts) do
    local host_rev = host:reverse()
```

An uppercase host therefore ends up in a bucket keyed on e.g. `moc.elpmaxe.esaCdexiM`, which the lowercase `$host` can never reach. The controller carries the host constraint on the service object only, so nothing normalizes it on the way in either.

### How

`internal/ssl.NormalizeHosts` already lowercases, trims and deduplicates hosts, and both the webhook conflict detector and the SSL indexer use it. The translator did not — so what the controller matched on and what it wrote to the data plane could disagree. This routes the four `service.Hosts` sites and the three `ssl.Snis` sites through it.

Two more defects fall out of the same gap:

- `dedupGatewaySSLSNIs` compares SNIs verbatim, so two listeners claiming the same SNI in different cases were never recognised as colliding and both reached the data plane, which rejects duplicate SNIs.
- `TranslateGRPCRoute` appends the listener hostnames to the route hostnames, which repeat in the common case, while the APISIX service schema declares `uniqueItems` on hosts. Covered by a new unit test that produces `["example.com", "example.com"]` without the fix.

Only `ApisixRoute` and `ApisixTls` can carry an uppercase host today — Ingress hosts are validated as DNS-1123 subdomains and the Gateway API `Hostname` type has a lowercase-only pattern — but the hostnames extracted from a certificate's SAN are unconstrained too.

### Verification

Reproduced end to end on `apache/apisix:3.16.0-debian` in standalone mode, with `service.hosts: ["MixedCase.example.com"]` and a route carrying no `hosts` of its own:

| request `Host` | `radixtree_host_uri` (default) | `radixtree_uri` |
| --- | --- | --- |
| `MixedCase.example.com` | 404 | 200 |
| `mixedcase.example.com` | 404 | 200 |
| `lowercase.example.com` (control) | 200 | 200 |

`radixtree_uri` is unaffected because lua-resty-radixtree lowercases hosts itself, on both the config and the request side.

The data plane asymmetry is fixed separately in apache/apisix#13781 and api7/api7-ee-3-gateway#2084; this change also keeps existing data plane versions working.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [ ] Have you modified the corresponding document?
- [x] Is this PR backward compatible?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hostnames are now normalized consistently across HTTP, gRPC, ingress, TLS, and gateway routing.
  * Duplicate hostnames are removed after normalization, improving routing and TLS consistency.
  * Requests using uppercase or lowercase host headers now resolve reliably to the same route.

* **Tests**
  * Added coverage for hostname normalization, duplicate removal, nil host handling, and mixed-case host requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->