### PR TITLE
fix: read L4 routes and ReferenceGrant as v1 instead of the older versions

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -210,14 +210,14 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-gateway-networking-k8s-io-v1alpha2-tcproute
+      path: /validate-gateway-networking-k8s-io-v1-tcproute
   failurePolicy: Ignore
-  name: vtcproute-v1alpha2.kb.io
+  name: vtcproute-v1.kb.io
   rules:
   - apiGroups:
     - gateway.networking.k8s.io
     apiVersions:
-    - v1alpha2
+    - v1
     operations:
     - CREATE
     - UPDATE
@@ -230,14 +230,14 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-gateway-networking-k8s-io-v1alpha2-udproute
+      path: /validate-gateway-networking-k8s-io-v1-udproute
   failurePolicy: Ignore
-  name: vudproute-v1alpha2.kb.io
+  name: vudproute-v1.kb.io
   rules:
   - apiGroups:
     - gateway.networking.k8s.io
     apiVersions:
-    - v1alpha2
+    - v1
     operations:
     - CREATE
     - UPDATE

--- a/docs/en/latest/concepts/gateway-api.md
+++ b/docs/en/latest/concepts/gateway-api.md
@@ -49,11 +49,15 @@ By supporting Gateway API, the APISIX Ingress controller can realize richer func
 | Gateway          | Partially supported | Partially supported    | Not supported                         | v1          |
 | HTTPRoute        | Supported           | Partially supported    | Not supported                         | v1          |
 | GRPCRoute        | Supported           | Supported              | Not supported                         | v1          |
-| ReferenceGrant   | Supported           | Not supported          | Not supported                         | v1beta1     |
-| TLSRoute         | Supported           | Supported              | Not supported                         | v1alpha2    |
-| TCPRoute         | Supported           | Supported              | Not supported                         | v1alpha2    |
-| UDPRoute         | Supported           | Supported              | Not supported                         | v1alpha2    |
+| ReferenceGrant   | Supported           | Not supported          | Not supported                         | v1          |
+| TLSRoute         | Supported           | Supported              | Not supported                         | v1          |
+| TCPRoute         | Supported           | Supported              | Not supported                         | v1          |
+| UDPRoute         | Supported           | Supported              | Not supported                         | v1          |
 | BackendTLSPolicy | Not supported       | Not supported          | Not supported                         | v1alpha3    |
+
+TLSRoute, TCPRoute, and UDPRoute are read as `v1`, which Gateway API promoted them to in 1.6. Gateway API 1.6 or later is therefore required for L4 routing: the `v1alpha2` versions of these resources are deprecated everywhere and are not even served by the standard channel CRDs. ReferenceGrant is read as `v1` for the same reason, although its `v1beta1` version is not deprecated and remains the storage version.
+
+Existing manifests that still declare an older version keep working as long as the installed CRDs serve it, because the API server converts them before they reach the controller. They should still be updated to `v1`.
 
 ## Examples
 

--- a/examples/httpbin/tcproute.yaml
+++ b/examples/httpbin/tcproute.yaml
@@ -61,7 +61,7 @@ spec:
       name: apisix-proxy-config
 ---
 
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-app-1

--- a/internal/adc/translator/l4route_serverport_test.go
+++ b/internal/adc/translator/l4route_serverport_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
@@ -99,11 +98,11 @@ func TestTranslateTCPRouteServerPort(t *testing.T) {
 			tctx.Listeners = tt.listeners
 			tctx.HasExplicitListenerMatch = tt.explicit
 
-			route := &gatewayv1alpha2.TCPRoute{
+			route := &gatewayv1.TCPRoute{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-tcp", Namespace: "default"},
-				Spec: gatewayv1alpha2.TCPRouteSpec{
-					Rules: []gatewayv1alpha2.TCPRouteRule{
-						{BackendRefs: []gatewayv1alpha2.BackendRef{}},
+				Spec: gatewayv1.TCPRouteSpec{
+					Rules: []gatewayv1.TCPRouteRule{
+						{BackendRefs: []gatewayv1.BackendRef{}},
 					},
 				},
 			}
@@ -177,11 +176,11 @@ func TestTranslateUDPRouteServerPort(t *testing.T) {
 			tctx.Listeners = tt.listeners
 			tctx.HasExplicitListenerMatch = tt.explicit
 
-			route := &gatewayv1alpha2.UDPRoute{
+			route := &gatewayv1.UDPRoute{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-udp", Namespace: "default"},
-				Spec: gatewayv1alpha2.UDPRouteSpec{
-					Rules: []gatewayv1alpha2.UDPRouteRule{
-						{BackendRefs: []gatewayv1alpha2.BackendRef{}},
+				Spec: gatewayv1.UDPRouteSpec{
+					Rules: []gatewayv1.UDPRouteRule{
+						{BackendRefs: []gatewayv1.BackendRef{}},
 					},
 				},
 			}

--- a/internal/adc/translator/l4route_test.go
+++ b/internal/adc/translator/l4route_test.go
@@ -30,7 +30,6 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -84,14 +83,14 @@ func TestTranslateTCPRouteWithL4RoutePolicy(t *testing.T) {
 				tctx.L4RoutePolicies[key] = tt.policy
 			}
 
-			route := &gatewayv1alpha2.TCPRoute{
+			route := &gatewayv1.TCPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-tcp",
 					Namespace: "default",
 				},
-				Spec: gatewayv1alpha2.TCPRouteSpec{
-					Rules: []gatewayv1alpha2.TCPRouteRule{
-						{BackendRefs: []gatewayv1alpha2.BackendRef{}},
+				Spec: gatewayv1.TCPRouteSpec{
+					Rules: []gatewayv1.TCPRouteRule{
+						{BackendRefs: []gatewayv1.BackendRef{}},
 					},
 				},
 			}
@@ -151,14 +150,14 @@ func TestTranslateUDPRouteWithL4RoutePolicy(t *testing.T) {
 				tctx.L4RoutePolicies[key] = tt.policy
 			}
 
-			route := &gatewayv1alpha2.UDPRoute{
+			route := &gatewayv1.UDPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-udp",
 					Namespace: "default",
 				},
-				Spec: gatewayv1alpha2.UDPRouteSpec{
-					Rules: []gatewayv1alpha2.UDPRouteRule{
-						{BackendRefs: []gatewayv1alpha2.BackendRef{}},
+				Spec: gatewayv1.UDPRouteSpec{
+					Rules: []gatewayv1.UDPRouteRule{
+						{BackendRefs: []gatewayv1.BackendRef{}},
 					},
 				},
 			}
@@ -230,20 +229,20 @@ func TestTranslateTLSRouteWithL4RoutePolicy(t *testing.T) {
 				tctx.L4RoutePolicies[key] = tt.policy
 			}
 
-			hostnames := make([]gatewayv1alpha2.Hostname, 0, len(tt.hostnames))
+			hostnames := make([]gatewayv1.Hostname, 0, len(tt.hostnames))
 			for _, h := range tt.hostnames {
-				hostnames = append(hostnames, gatewayv1alpha2.Hostname(h))
+				hostnames = append(hostnames, gatewayv1.Hostname(h))
 			}
 
-			route := &gatewayv1alpha2.TLSRoute{
+			route := &gatewayv1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-tls",
 					Namespace: "default",
 				},
-				Spec: gatewayv1alpha2.TLSRouteSpec{
+				Spec: gatewayv1.TLSRouteSpec{
 					Hostnames: hostnames,
-					Rules: []gatewayv1alpha2.TLSRouteRule{
-						{BackendRefs: []gatewayv1alpha2.BackendRef{}},
+					Rules: []gatewayv1.TLSRouteRule{
+						{BackendRefs: []gatewayv1.BackendRef{}},
 					},
 				},
 			}
@@ -330,14 +329,14 @@ func TestTranslateTCPRouteUpstreamScheme(t *testing.T) {
 		},
 	}
 
-	route := &gatewayv1alpha2.TCPRoute{
+	route := &gatewayv1.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-tcp",
 			Namespace: namespace,
 		},
-		Spec: gatewayv1alpha2.TCPRouteSpec{
-			Rules: []gatewayv1alpha2.TCPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{{
+		Spec: gatewayv1.TCPRouteSpec{
+			Rules: []gatewayv1.TCPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{{
 					BackendObjectReference: gatewayv1.BackendObjectReference{
 						Name: gatewayv1.ObjectName(serviceName),
 						Port: ptr.To(portNumber),

--- a/internal/adc/translator/policies.go
+++ b/internal/adc/translator/policies.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
@@ -240,7 +239,7 @@ func (t *Translator) AttachL4RoutePolicyPlugins(
 			continue
 		}
 		for _, ref := range policy.Spec.TargetRefs {
-			if string(ref.Group) != gatewayv1alpha2.GroupName {
+			if string(ref.Group) != gatewayv1.GroupName {
 				continue
 			}
 			if string(ref.Kind) != routeKind {

--- a/internal/adc/translator/tcproute.go
+++ b/internal/adc/translator/tcproute.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -105,7 +104,7 @@ func (t *Translator) buildL4StreamRoutes(tctx *provider.TranslateContext, namesp
 	return streamRoutes
 }
 
-func (t *Translator) TranslateTCPRoute(tctx *provider.TranslateContext, tcpRoute *gatewayv1alpha2.TCPRoute) (*TranslateResult, error) {
+func (t *Translator) TranslateTCPRoute(tctx *provider.TranslateContext, tcpRoute *gatewayv1.TCPRoute) (*TranslateResult, error) {
 	result := &TranslateResult{}
 	rules := tcpRoute.Spec.Rules
 	labels := label.GenLabel(tcpRoute)

--- a/internal/adc/translator/tlsroute.go
+++ b/internal/adc/translator/tlsroute.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -31,7 +30,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/types"
 )
 
-func (t *Translator) TranslateTLSRoute(tctx *provider.TranslateContext, tlsRoute *gatewayv1alpha2.TLSRoute) (*TranslateResult, error) {
+func (t *Translator) TranslateTLSRoute(tctx *provider.TranslateContext, tlsRoute *gatewayv1.TLSRoute) (*TranslateResult, error) {
 	result := &TranslateResult{}
 	rules := tlsRoute.Spec.Rules
 	labels := label.GenLabel(tlsRoute)

--- a/internal/adc/translator/udproute.go
+++ b/internal/adc/translator/udproute.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -31,7 +30,7 @@ import (
 	"github.com/apache/apisix-ingress-controller/internal/types"
 )
 
-func (t *Translator) TranslateUDPRoute(tctx *provider.TranslateContext, udpRoute *gatewayv1alpha2.UDPRoute) (*TranslateResult, error) {
+func (t *Translator) TranslateUDPRoute(tctx *provider.TranslateContext, udpRoute *gatewayv1.UDPRoute) (*TranslateResult, error) {
 	result := &TranslateResult{}
 	rules := udpRoute.Spec.Rules
 	labels := label.GenLabel(udpRoute)

--- a/internal/controller/consumer_controller_test.go
+++ b/internal/controller/consumer_controller_test.go
@@ -30,7 +30,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/provider"
@@ -48,7 +47,6 @@ func buildConsumerReconciler(t *testing.T, objs ...runtime.Object) *ConsumerReco
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, v1alpha1.AddToScheme(scheme))
 	require.NoError(t, gatewayv1.Install(scheme))
-	require.NoError(t, v1beta1.Install(scheme))
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
 	return &ConsumerReconciler{Client: cli, Log: logr.Discard()}
@@ -75,16 +73,16 @@ func victimSecret() *corev1.Secret {
 	}
 }
 
-func secretGrant() *v1beta1.ReferenceGrant {
-	return &v1beta1.ReferenceGrant{
+func secretGrant() *gatewayv1.ReferenceGrant {
+	return &gatewayv1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{Name: "allow-consumer", Namespace: secretNS},
-		Spec: v1beta1.ReferenceGrantSpec{
-			From: []v1beta1.ReferenceGrantFrom{{
-				Group:     v1beta1.Group(v1alpha1.GroupVersion.Group),
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{
+				Group:     gatewayv1.Group(v1alpha1.GroupVersion.Group),
 				Kind:      "Consumer",
 				Namespace: consumerNS,
 			}},
-			To: []v1beta1.ReferenceGrantTo{{
+			To: []gatewayv1.ReferenceGrantTo{{
 				Group: "",
 				Kind:  "Secret",
 			}},

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -34,8 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
@@ -98,38 +96,38 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	if GetEnableReferenceGrant() {
-		bdr.Watches(&v1beta1.ReferenceGrant{},
+		bdr.Watches(&gatewayv1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
 			builder.WithPredicates(referenceGrantPredicates(KindGateway)),
 		)
 	}
-	hasTCPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TCPRoute{})
+	hasTCPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1.TCPRoute{})
 	if err != nil {
 		return err
 	}
 	if hasTCPRoute {
 		bdr.Watches(
-			&gatewayv1alpha2.TCPRoute{},
+			&gatewayv1.TCPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
-	hasTLSRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.TLSRoute{})
+	hasTLSRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1.TLSRoute{})
 	if err != nil {
 		return err
 	}
 	if hasTLSRoute {
 		bdr.Watches(
-			&gatewayv1alpha2.TLSRoute{},
+			&gatewayv1.TLSRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
-	hasUDPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1alpha2.UDPRoute{})
+	hasUDPRoute, err := pkgutils.HasAPIResource(mgr, &gatewayv1.UDPRoute{})
 	if err != nil {
 		return err
 	}
 	if hasUDPRoute {
 		bdr.Watches(
-			&gatewayv1alpha2.UDPRoute{},
+			&gatewayv1.UDPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.listGatewaysForStatusParentRefs),
 		)
 	}
@@ -435,12 +433,12 @@ func (r *GatewayReconciler) listGatewaysForConfigMap(ctx context.Context, obj cl
 }
 
 func (r *GatewayReconciler) listReferenceGrantsForGateway(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
-	grant, ok := obj.(*v1beta1.ReferenceGrant)
+	grant, ok := obj.(*gatewayv1.ReferenceGrant)
 	if !ok {
 		r.Log.Error(
 			errors.New("unexpected object type"),
 			"ReferenceGrant watch predicate received unexpected object type",
-			"expected", FullTypeName(new(v1beta1.ReferenceGrant)), "found", FullTypeName(obj),
+			"expected", FullTypeName(new(gatewayv1.ReferenceGrant)), "found", FullTypeName(obj),
 		)
 		return nil
 	}
@@ -452,10 +450,10 @@ func (r *GatewayReconciler) listReferenceGrantsForGateway(ctx context.Context, o
 	}
 
 	for _, gateway := range gatewayList.Items {
-		gw := v1beta1.ReferenceGrantFrom{
+		gw := gatewayv1.ReferenceGrantFrom{
 			Group:     gatewayv1.GroupName,
 			Kind:      KindGateway,
-			Namespace: v1beta1.Namespace(gateway.GetNamespace()),
+			Namespace: gatewayv1.Namespace(gateway.GetNamespace()),
 		}
 		for _, from := range grant.Spec.From {
 			if from == gw {
@@ -495,10 +493,10 @@ func (r *GatewayReconciler) processListenerConfig(tctx *provider.TranslateContex
 				// or the data plane would program a certificate the target namespace never
 				// permitted. The listener status already reports RefNotPermitted for this.
 				if !checkReferenceGrant(context.Background(), r.Client,
-					v1beta1.ReferenceGrantFrom{
+					gatewayv1.ReferenceGrantFrom{
 						Group:     gatewayv1.GroupName,
 						Kind:      KindGateway,
-						Namespace: v1beta1.Namespace(gateway.Namespace),
+						Namespace: gatewayv1.Namespace(gateway.Namespace),
 					},
 					gatewayv1.ObjectReference{
 						Group:     corev1.GroupName,
@@ -542,10 +540,10 @@ func (r *GatewayReconciler) processListenerConfig(tctx *provider.TranslateContex
 				// data plane would enable downstream mTLS with a CA the target namespace
 				// never permitted. The listener status already reports RefNotPermitted.
 				if !checkReferenceGrant(context.Background(), r.Client,
-					v1beta1.ReferenceGrantFrom{
+					gatewayv1.ReferenceGrantFrom{
 						Group:     gatewayv1.GroupName,
 						Kind:      KindGateway,
-						Namespace: v1beta1.Namespace(gateway.Namespace),
+						Namespace: gatewayv1.Namespace(gateway.Namespace),
 					},
 					gatewayv1.ObjectReference{
 						Group:     corev1.GroupName,

--- a/internal/controller/gateway_controller_refgrant_test.go
+++ b/internal/controller/gateway_controller_refgrant_test.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/internal/provider"
 )
@@ -79,16 +78,16 @@ func gatewayWithRefs(refNamespace string) *gatewayv1.Gateway {
 
 // referenceGrant permits a Gateway in "default" to reference Secrets and
 // ConfigMaps in grantNamespace.
-func referenceGrant(grantNamespace string) *v1beta1.ReferenceGrant {
-	return &v1beta1.ReferenceGrant{
+func referenceGrant(grantNamespace string) *gatewayv1.ReferenceGrant {
+	return &gatewayv1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{Namespace: grantNamespace, Name: "grant"},
-		Spec: v1beta1.ReferenceGrantSpec{
-			From: []v1beta1.ReferenceGrantFrom{{
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{
 				Group:     gatewayv1.GroupName,
 				Kind:      KindGateway,
 				Namespace: "default",
 			}},
-			To: []v1beta1.ReferenceGrantTo{
+			To: []gatewayv1.ReferenceGrantTo{
 				{Group: "", Kind: KindSecret},
 				{Group: "", Kind: KindConfigMap},
 			},
@@ -104,7 +103,6 @@ func TestProcessListenerConfig_CrossNamespaceReferenceGrant(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, gatewayv1.Install(scheme))
-	require.NoError(t, v1beta1.Install(scheme))
 
 	certSecret := func(ns string) *corev1.Secret {
 		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "cert"}}

--- a/internal/controller/grpcroute_controller.go
+++ b/internal/controller/grpcroute_controller.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
@@ -112,7 +111,7 @@ func (r *GRPCRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	if GetEnableReferenceGrant() {
-		bdr.Watches(&v1beta1.ReferenceGrant{},
+		bdr.Watches(&gatewayv1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listGRPCRoutesForReferenceGrant),
 			builder.WithPredicates(referenceGrantPredicates(KindGRPCRoute)),
 		)
@@ -415,10 +414,10 @@ func (r *GRPCRouteReconciler) processGRPCRouteBackendRefs(tctx *provider.Transla
 		if grNN.Namespace != targetNN.Namespace {
 			if permitted := checkReferenceGrant(tctx,
 				r.Client,
-				v1beta1.ReferenceGrantFrom{
+				gatewayv1.ReferenceGrantFrom{
 					Group:     gatewayv1.GroupName,
 					Kind:      KindGRPCRoute,
-					Namespace: v1beta1.Namespace(grNN.Namespace),
+					Namespace: gatewayv1.Namespace(grNN.Namespace),
 				},
 				gatewayv1.ObjectReference{
 					Group:     corev1.GroupName,
@@ -428,7 +427,7 @@ func (r *GRPCRouteReconciler) processGRPCRouteBackendRefs(tctx *provider.Transla
 				},
 			); !permitted {
 				terr = types.ReasonError{
-					Reason:  string(v1beta1.RouteReasonRefNotPermitted),
+					Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
 					Message: fmt.Sprintf("%s is in a different namespace than the GRPCRoute %s and no ReferenceGrant allowing reference is configured", targetNN, grNN),
 				}
 				continue
@@ -556,7 +555,7 @@ func (r *GRPCRouteReconciler) listGRPCRoutesForGatewayProxy(ctx context.Context,
 }
 
 func (r *GRPCRouteReconciler) listGRPCRoutesForReferenceGrant(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
-	grant, ok := obj.(*v1beta1.ReferenceGrant)
+	grant, ok := obj.(*gatewayv1.ReferenceGrant)
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to ReferenceGrant")
 		return nil
@@ -569,10 +568,10 @@ func (r *GRPCRouteReconciler) listGRPCRoutesForReferenceGrant(ctx context.Contex
 	}
 
 	for _, grpcRoute := range grpcRouteList.Items {
-		gr := v1beta1.ReferenceGrantFrom{
+		gr := gatewayv1.ReferenceGrantFrom{
 			Group:     gatewayv1.GroupName,
 			Kind:      KindGRPCRoute,
-			Namespace: v1beta1.Namespace(grpcRoute.GetNamespace()),
+			Namespace: gatewayv1.Namespace(grpcRoute.GetNamespace()),
 		}
 		for _, from := range grant.Spec.From {
 			if from == gr {

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -40,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
@@ -143,7 +142,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	if GetEnableReferenceGrant() {
-		bdr.Watches(&v1beta1.ReferenceGrant{},
+		bdr.Watches(&gatewayv1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForReferenceGrant),
 			builder.WithPredicates(referenceGrantPredicates(KindHTTPRoute)),
 		)
@@ -549,10 +548,10 @@ func (r *HTTPRouteReconciler) processHTTPRouteBackendRefs(tctx *provider.Transla
 		if hrNN.Namespace != targetNN.Namespace {
 			if permitted := checkReferenceGrant(tctx,
 				r.Client,
-				v1beta1.ReferenceGrantFrom{
+				gatewayv1.ReferenceGrantFrom{
 					Group:     gatewayv1.GroupName,
 					Kind:      KindHTTPRoute,
-					Namespace: v1beta1.Namespace(hrNN.Namespace),
+					Namespace: gatewayv1.Namespace(hrNN.Namespace),
 				},
 				gatewayv1.ObjectReference{
 					Group:     corev1.GroupName,
@@ -562,7 +561,7 @@ func (r *HTTPRouteReconciler) processHTTPRouteBackendRefs(tctx *provider.Transla
 				},
 			); !permitted {
 				terr = types.ReasonError{
-					Reason:  string(v1beta1.RouteReasonRefNotPermitted),
+					Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
 					Message: fmt.Sprintf("%s is in a different namespace than the HTTPRoute %s and no ReferenceGrant allowing reference is configured", targetNN, hrNN),
 				}
 				continue
@@ -715,7 +714,7 @@ func (r *HTTPRouteReconciler) listHTTPRoutesForGatewayProxy(ctx context.Context,
 }
 
 func (r *HTTPRouteReconciler) listHTTPRoutesForReferenceGrant(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
-	grant, ok := obj.(*v1beta1.ReferenceGrant)
+	grant, ok := obj.(*gatewayv1.ReferenceGrant)
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to ReferenceGrant")
 		return nil
@@ -728,10 +727,10 @@ func (r *HTTPRouteReconciler) listHTTPRoutesForReferenceGrant(ctx context.Contex
 	}
 
 	for _, httpRoute := range httpRouteList.Items {
-		hr := v1beta1.ReferenceGrantFrom{
+		hr := gatewayv1.ReferenceGrantFrom{
 			Group:     gatewayv1.GroupName,
 			Kind:      KindHTTPRoute,
-			Namespace: v1beta1.Namespace(httpRoute.GetNamespace()),
+			Namespace: gatewayv1.Namespace(httpRoute.GetNamespace()),
 		}
 		for _, from := range grant.Spec.From {
 			if from == hr {

--- a/internal/controller/indexer/indexer.go
+++ b/internal/controller/indexer/indexer.go
@@ -29,7 +29,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -65,14 +64,14 @@ func SetupIndexer(mgr ctrl.Manager) error {
 	// Gateway API indexers - conditional setup based on API availability
 	if !config.ControllerConfig.DisableGatewayAPI {
 		for resource, setup := range map[client.Object]func(ctrl.Manager) error{
-			&gatewayv1.Gateway{}:        setupGatewayIndexer,
-			&gatewayv1.HTTPRoute{}:      setupHTTPRouteIndexer,
-			&gatewayv1.GRPCRoute{}:      setupGRPCRouteIndexer,
-			&gatewayv1alpha2.TCPRoute{}: setupTCPRouteIndexer,
-			&gatewayv1alpha2.UDPRoute{}: setupUDPRouteIndexer,
-			&gatewayv1alpha2.TLSRoute{}: setupTLSRouteIndexer,
-			&gatewayv1.GatewayClass{}:   setupGatewayClassIndexer,
-			&v1alpha1.Consumer{}:        setupConsumerIndexer,
+			&gatewayv1.Gateway{}:      setupGatewayIndexer,
+			&gatewayv1.HTTPRoute{}:    setupHTTPRouteIndexer,
+			&gatewayv1.GRPCRoute{}:    setupGRPCRouteIndexer,
+			&gatewayv1.TCPRoute{}:     setupTCPRouteIndexer,
+			&gatewayv1.UDPRoute{}:     setupUDPRouteIndexer,
+			&gatewayv1.TLSRoute{}:     setupTLSRouteIndexer,
+			&gatewayv1.GatewayClass{}: setupGatewayClassIndexer,
+			&v1alpha1.Consumer{}:      setupConsumerIndexer,
 		} {
 			installed, err := utils.HasAPIResource(mgr, resource)
 			if err != nil {
@@ -313,7 +312,7 @@ func setHTTPRoutePolicyIndexer(mgr ctrl.Manager) error {
 func setupTCPRouteIndexer(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&gatewayv1alpha2.TCPRoute{},
+		&gatewayv1.TCPRoute{},
 		ParentRefs,
 		TCPRouteParentRefsIndexFunc,
 	); err != nil {
@@ -322,7 +321,7 @@ func setupTCPRouteIndexer(mgr ctrl.Manager) error {
 
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&gatewayv1alpha2.TCPRoute{},
+		&gatewayv1.TCPRoute{},
 		ServiceIndexRef,
 		TCPPRouteServiceIndexFunc,
 	); err != nil {
@@ -334,7 +333,7 @@ func setupTCPRouteIndexer(mgr ctrl.Manager) error {
 func setupUDPRouteIndexer(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&gatewayv1alpha2.UDPRoute{},
+		&gatewayv1.UDPRoute{},
 		ParentRefs,
 		UDPRouteParentRefsIndexFunc,
 	); err != nil {
@@ -343,7 +342,7 @@ func setupUDPRouteIndexer(mgr ctrl.Manager) error {
 
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&gatewayv1alpha2.UDPRoute{},
+		&gatewayv1.UDPRoute{},
 		ServiceIndexRef,
 		UDPRouteServiceIndexFunc,
 	); err != nil {
@@ -724,7 +723,7 @@ func HTTPRouteParentRefsIndexFunc(rawObj client.Object) []string {
 }
 
 func TCPRouteParentRefsIndexFunc(rawObj client.Object) []string {
-	tr := rawObj.(*gatewayv1alpha2.TCPRoute)
+	tr := rawObj.(*gatewayv1.TCPRoute)
 	keys := make([]string, 0, len(tr.Spec.ParentRefs))
 	for _, ref := range tr.Spec.ParentRefs {
 		ns := tr.GetNamespace()
@@ -737,7 +736,7 @@ func TCPRouteParentRefsIndexFunc(rawObj client.Object) []string {
 }
 
 func UDPRouteParentRefsIndexFunc(rawObj client.Object) []string {
-	ur := rawObj.(*gatewayv1alpha2.UDPRoute)
+	ur := rawObj.(*gatewayv1.UDPRoute)
 	keys := make([]string, 0, len(ur.Spec.ParentRefs))
 	for _, ref := range ur.Spec.ParentRefs {
 		ns := ur.GetNamespace()
@@ -768,7 +767,7 @@ func HTTPRouteServiceIndexFunc(rawObj client.Object) []string {
 }
 
 func TCPPRouteServiceIndexFunc(rawObj client.Object) []string {
-	tr := rawObj.(*gatewayv1alpha2.TCPRoute)
+	tr := rawObj.(*gatewayv1.TCPRoute)
 	keys := make([]string, 0, len(tr.Spec.Rules))
 	for _, rule := range tr.Spec.Rules {
 		for _, backend := range rule.BackendRefs {
@@ -786,7 +785,7 @@ func TCPPRouteServiceIndexFunc(rawObj client.Object) []string {
 }
 
 func UDPRouteServiceIndexFunc(rawObj client.Object) []string {
-	ur := rawObj.(*gatewayv1alpha2.UDPRoute)
+	ur := rawObj.(*gatewayv1.UDPRoute)
 	keys := make([]string, 0, len(ur.Spec.Rules))
 	for _, rule := range ur.Spec.Rules {
 		for _, backend := range rule.BackendRefs {

--- a/internal/controller/indexer/tlsroute.go
+++ b/internal/controller/indexer/tlsroute.go
@@ -22,7 +22,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 )
@@ -30,7 +30,7 @@ import (
 func setupTLSRouteIndexer(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&gatewayv1alpha2.TLSRoute{},
+		&gatewayv1.TLSRoute{},
 		ParentRefs,
 		TLSRouteParentRefsIndexFunc,
 	); err != nil {
@@ -39,7 +39,7 @@ func setupTLSRouteIndexer(mgr ctrl.Manager) error {
 
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
-		&gatewayv1alpha2.TLSRoute{},
+		&gatewayv1.TLSRoute{},
 		ServiceIndexRef,
 		TLSPRouteServiceIndexFunc,
 	); err != nil {
@@ -49,7 +49,7 @@ func setupTLSRouteIndexer(mgr ctrl.Manager) error {
 }
 
 func TLSRouteParentRefsIndexFunc(rawObj client.Object) []string {
-	tr := rawObj.(*gatewayv1alpha2.TLSRoute)
+	tr := rawObj.(*gatewayv1.TLSRoute)
 	keys := make([]string, 0, len(tr.Spec.ParentRefs))
 	for _, ref := range tr.Spec.ParentRefs {
 		ns := tr.GetNamespace()
@@ -62,7 +62,7 @@ func TLSRouteParentRefsIndexFunc(rawObj client.Object) []string {
 }
 
 func TLSPRouteServiceIndexFunc(rawObj client.Object) []string {
-	tr := rawObj.(*gatewayv1alpha2.TLSRoute)
+	tr := rawObj.(*gatewayv1.TLSRoute)
 	keys := make([]string, 0, len(tr.Spec.Rules))
 	for _, rule := range tr.Spec.Rules {
 		for _, backend := range rule.BackendRefs {

--- a/internal/controller/policies.go
+++ b/internal/controller/policies.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
@@ -200,7 +199,7 @@ func SetAncestors(status *v1alpha1.PolicyStatus, parentRefs []gatewayv1.ParentRe
 		ancestorStatus := gatewayv1.PolicyAncestorStatus{
 			AncestorRef:    parent,
 			Conditions:     []metav1.Condition{condition},
-			ControllerName: gatewayv1alpha2.GatewayController(config.ControllerConfig.ControllerName),
+			ControllerName: gatewayv1.GatewayController(config.ControllerConfig.ControllerName),
 		}
 		if SetAncestorStatus(status, ancestorStatus) {
 			updated = true
@@ -243,7 +242,7 @@ func l4RoutePolicyMatchesRoute(policy v1alpha1.L4RoutePolicy, routeKind, routeNa
 		return false
 	}
 	for _, ref := range policy.Spec.TargetRefs {
-		if string(ref.Group) != gatewayv1alpha2.GroupName {
+		if string(ref.Group) != gatewayv1.GroupName {
 			continue
 		}
 		if string(ref.Kind) != routeKind {
@@ -270,7 +269,7 @@ func ProcessL4RoutePolicy(
 	routeNamespace, routeName, routeKind string,
 ) {
 	var list v1alpha1.L4RoutePolicyList
-	key := indexer.GenIndexKeyWithGK(gatewayv1alpha2.GroupName, routeKind, routeNamespace, routeName)
+	key := indexer.GenIndexKeyWithGK(gatewayv1.GroupName, routeKind, routeNamespace, routeName)
 	if err := c.List(tctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
 		log.Error(err, "failed to list L4RoutePolicy", "namespace", routeNamespace, "name", routeName, "kind", routeKind)
 		return
@@ -349,7 +348,7 @@ func ProcessL4RoutePolicy(
 // no longer referenced by any of them are removed.
 func updateL4RoutePolicyStatusOnDeleting(ctx context.Context, c client.Client, updater status.Updater, log logr.Logger, nn types.NamespacedName, routeKind string) {
 	var list v1alpha1.L4RoutePolicyList
-	key := indexer.GenIndexKeyWithGK(gatewayv1alpha2.GroupName, routeKind, nn.Namespace, nn.Name)
+	key := indexer.GenIndexKeyWithGK(gatewayv1.GroupName, routeKind, nn.Namespace, nn.Name)
 	if err := c.List(ctx, &list, client.MatchingFields{indexer.PolicyTargetRefs: key}); err != nil {
 		log.Error(err, "failed to list L4RoutePolicy on route deletion", "namespace", nn.Namespace, "name", nn.Name)
 		return
@@ -358,7 +357,7 @@ func updateL4RoutePolicyStatusOnDeleting(ctx context.Context, c client.Client, u
 		policy := list.Items[i]
 		var parentRefs []gatewayv1.ParentReference
 		for _, ref := range policy.Spec.TargetRefs {
-			if string(ref.Group) != gatewayv1alpha2.GroupName {
+			if string(ref.Group) != gatewayv1.GroupName {
 				continue
 			}
 			// The deleted route returns NotFound here and is naturally skipped.
@@ -377,19 +376,19 @@ func updateL4RoutePolicyStatusOnDeleting(ctx context.Context, c client.Client, u
 func l4RouteParentRefs(ctx context.Context, c client.Client, kind string, nn types.NamespacedName) ([]gatewayv1.ParentReference, bool) {
 	switch kind {
 	case internaltypes.KindTCPRoute:
-		var route gatewayv1alpha2.TCPRoute
+		var route gatewayv1.TCPRoute
 		if err := c.Get(ctx, nn, &route); err != nil {
 			return nil, false
 		}
 		return route.Spec.ParentRefs, true
 	case internaltypes.KindUDPRoute:
-		var route gatewayv1alpha2.UDPRoute
+		var route gatewayv1.UDPRoute
 		if err := c.Get(ctx, nn, &route); err != nil {
 			return nil, false
 		}
 		return route.Spec.ParentRefs, true
 	case internaltypes.KindTLSRoute:
-		var route gatewayv1alpha2.TLSRoute
+		var route gatewayv1.TLSRoute
 		if err := c.Get(ctx, nn, &route); err != nil {
 			return nil, false
 		}

--- a/internal/controller/tcproute_controller.go
+++ b/internal/controller/tcproute_controller.go
@@ -35,8 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
@@ -68,7 +66,7 @@ type TCPRouteReconciler struct { //nolint:revive
 func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	bdr := ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1alpha2.TCPRoute{}).
+		For(&gatewayv1.TCPRoute{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Watches(&discoveryv1.EndpointSlice{},
 			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesByServiceRef),
@@ -113,7 +111,7 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	if GetEnableReferenceGrant() {
-		bdr.Watches(&v1beta1.ReferenceGrant{},
+		bdr.Watches(&gatewayv1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForReferenceGrant),
 			builder.WithPredicates(referenceGrantPredicates(KindTCPRoute)),
 		)
@@ -129,7 +127,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForBackendTrafficPolicy(ctx context.Co
 		return nil
 	}
 
-	tcprouteList := []gatewayv1alpha2.TCPRoute{}
+	tcprouteList := []gatewayv1.TCPRoute{}
 	for _, targetRef := range policy.Spec.TargetRefs {
 		service := &corev1.Service{}
 		if err := r.Get(ctx, client.ObjectKey{
@@ -141,7 +139,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForBackendTrafficPolicy(ctx context.Co
 			}
 			continue
 		}
-		tcprList := &gatewayv1alpha2.TCPRouteList{}
+		tcprList := &gatewayv1.TCPRouteList{}
 		if err := r.List(ctx, tcprList, client.MatchingFields{
 			indexer.ServiceIndexRef: indexer.GenIndexKey(policy.Namespace, string(targetRef.Name)),
 		}); err != nil {
@@ -175,7 +173,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForGateway(ctx context.Context, obj cl
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to Gateway")
 	}
-	tcprList := &gatewayv1alpha2.TCPRouteList{}
+	tcprList := &gatewayv1.TCPRouteList{}
 	if err := r.List(ctx, tcprList, client.MatchingFields{
 		indexer.ParentRefs: indexer.GenIndexKey(gateway.Namespace, gateway.Name),
 	}); err != nil {
@@ -219,7 +217,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForGatewayProxy(ctx context.Context, o
 
 	// for each gateway, find all TCPRoute resources that reference it
 	for _, gateway := range gatewayList.Items {
-		tcpRouteList := &gatewayv1alpha2.TCPRouteList{}
+		tcpRouteList := &gatewayv1.TCPRouteList{}
 		if err := r.List(ctx, tcpRouteList, client.MatchingFields{
 			indexer.ParentRefs: indexer.GenIndexKey(gateway.Namespace, gateway.Name),
 		}); err != nil {
@@ -241,8 +239,8 @@ func (r *TCPRouteReconciler) listTCPRoutesForGatewayProxy(ctx context.Context, o
 }
 
 func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	defer r.Readier.Done(&gatewayv1alpha2.TCPRoute{}, req.NamespacedName)
-	tr := new(gatewayv1alpha2.TCPRoute)
+	defer r.Readier.Done(&gatewayv1.TCPRoute{}, req.NamespacedName)
+	tr := new(gatewayv1.TCPRoute)
 	if err := r.Get(ctx, req.NamespacedName, tr); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			tr.Namespace = req.Namespace
@@ -250,7 +248,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 			tr.TypeMeta = metav1.TypeMeta{
 				Kind:       KindTCPRoute,
-				APIVersion: gatewayv1alpha2.GroupVersion.String(),
+				APIVersion: gatewayv1.GroupVersion.String(),
 			}
 
 			if err := r.Provider.Delete(ctx, tr); err != nil {
@@ -339,9 +337,9 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	r.Updater.Update(status.Update{
 		NamespacedName: utils.NamespacedName(tr),
-		Resource:       &gatewayv1alpha2.TCPRoute{},
+		Resource:       &gatewayv1.TCPRoute{},
 		Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-			t, ok := obj.(*gatewayv1alpha2.TCPRoute)
+			t, ok := obj.(*gatewayv1.TCPRoute)
 			if !ok {
 				err := fmt.Errorf("unsupported object type %T", obj)
 				panic(err)
@@ -361,7 +359,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
-func (r *TCPRouteReconciler) processTCPRoute(tctx *provider.TranslateContext, tcpRoute *gatewayv1alpha2.TCPRoute) error {
+func (r *TCPRouteReconciler) processTCPRoute(tctx *provider.TranslateContext, tcpRoute *gatewayv1.TCPRoute) error {
 	var terror error
 	for _, rule := range tcpRoute.Spec.Rules {
 		for _, backend := range rule.BackendRefs {
@@ -419,10 +417,10 @@ func (r *TCPRouteReconciler) processTCPRouteBackendRefs(tctx *provider.Translate
 		if trNN.Namespace != targetNN.Namespace {
 			if permitted := checkReferenceGrant(tctx,
 				r.Client,
-				v1beta1.ReferenceGrantFrom{
+				gatewayv1.ReferenceGrantFrom{
 					Group:     gatewayv1.GroupName,
 					Kind:      KindTCPRoute,
-					Namespace: v1beta1.Namespace(trNN.Namespace),
+					Namespace: gatewayv1.Namespace(trNN.Namespace),
 				},
 				gatewayv1.ObjectReference{
 					Group:     corev1.GroupName,
@@ -432,7 +430,7 @@ func (r *TCPRouteReconciler) processTCPRouteBackendRefs(tctx *provider.Translate
 				},
 			); !permitted {
 				terr = types.ReasonError{
-					Reason:  string(v1beta1.RouteReasonRefNotPermitted),
+					Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
 					Message: fmt.Sprintf("%s is in a different namespace than the TCPRoute %s and no ReferenceGrant allowing reference is configured", targetNN, trNN),
 				}
 				continue
@@ -475,23 +473,23 @@ func (r *TCPRouteReconciler) processTCPRouteBackendRefs(tctx *provider.Translate
 }
 
 func (r *TCPRouteReconciler) listTCPRoutesForReferenceGrant(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
-	grant, ok := obj.(*v1beta1.ReferenceGrant)
+	grant, ok := obj.(*gatewayv1.ReferenceGrant)
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to ReferenceGrant")
 		return nil
 	}
 
-	var tcpRouteList gatewayv1alpha2.TCPRouteList
+	var tcpRouteList gatewayv1.TCPRouteList
 	if err := r.List(ctx, &tcpRouteList); err != nil {
 		r.Log.Error(err, "failed to list tcproutes for reference ReferenceGrant", "ReferenceGrant", k8stypes.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()})
 		return nil
 	}
 
 	for _, tcpRoute := range tcpRouteList.Items {
-		tr := v1beta1.ReferenceGrantFrom{
+		tr := gatewayv1.ReferenceGrantFrom{
 			Group:     gatewayv1.GroupName,
 			Kind:      KindTCPRoute,
-			Namespace: v1beta1.Namespace(tcpRoute.GetNamespace()),
+			Namespace: gatewayv1.Namespace(tcpRoute.GetNamespace()),
 		}
 		for _, from := range grant.Spec.From {
 			if from == tr {
@@ -516,7 +514,7 @@ func (r *TCPRouteReconciler) listTCPRoutesByServiceRef(ctx context.Context, obj 
 	namespace := endpointSlice.GetNamespace()
 	serviceName := endpointSlice.Labels[discoveryv1.LabelServiceName]
 
-	trList := &gatewayv1alpha2.TCPRouteList{}
+	trList := &gatewayv1.TCPRouteList{}
 	if err := r.List(ctx, trList, client.MatchingFields{
 		indexer.ServiceIndexRef: indexer.GenIndexKey(namespace, serviceName),
 	}); err != nil {

--- a/internal/controller/tlsroute_controller.go
+++ b/internal/controller/tlsroute_controller.go
@@ -35,8 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
@@ -68,7 +66,7 @@ type TLSRouteReconciler struct { //nolint:revive
 func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	bdr := ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1alpha2.TLSRoute{}).
+		For(&gatewayv1.TLSRoute{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Watches(&discoveryv1.EndpointSlice{},
 			handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesByServiceRef),
@@ -113,7 +111,7 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	if GetEnableReferenceGrant() {
-		bdr.Watches(&v1beta1.ReferenceGrant{},
+		bdr.Watches(&gatewayv1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForReferenceGrant),
 			builder.WithPredicates(referenceGrantPredicates(types.KindTLSRoute)),
 		)
@@ -129,7 +127,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForBackendTrafficPolicy(ctx context.Co
 		return nil
 	}
 
-	tlsrouteList := []gatewayv1alpha2.TLSRoute{}
+	tlsrouteList := []gatewayv1.TLSRoute{}
 	for _, targetRef := range policy.Spec.TargetRefs {
 		service := &corev1.Service{}
 		if err := r.Get(ctx, client.ObjectKey{
@@ -141,7 +139,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForBackendTrafficPolicy(ctx context.Co
 			}
 			continue
 		}
-		trList := &gatewayv1alpha2.TLSRouteList{}
+		trList := &gatewayv1.TLSRouteList{}
 		if err := r.List(ctx, trList, client.MatchingFields{
 			indexer.ServiceIndexRef: indexer.GenIndexKey(policy.Namespace, string(targetRef.Name)),
 		}); err != nil {
@@ -175,7 +173,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForGateway(ctx context.Context, obj cl
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to Gateway")
 	}
-	trList := &gatewayv1alpha2.TLSRouteList{}
+	trList := &gatewayv1.TLSRouteList{}
 	if err := r.List(ctx, trList, client.MatchingFields{
 		indexer.ParentRefs: indexer.GenIndexKey(gateway.Namespace, gateway.Name),
 	}); err != nil {
@@ -219,7 +217,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForGatewayProxy(ctx context.Context, o
 
 	// for each gateway, find all TLSRoute resources that reference it
 	for _, gateway := range gatewayList.Items {
-		tlsRouteList := &gatewayv1alpha2.TLSRouteList{}
+		tlsRouteList := &gatewayv1.TLSRouteList{}
 		if err := r.List(ctx, tlsRouteList, client.MatchingFields{
 			indexer.ParentRefs: indexer.GenIndexKey(gateway.Namespace, gateway.Name),
 		}); err != nil {
@@ -241,8 +239,8 @@ func (r *TLSRouteReconciler) listTLSRoutesForGatewayProxy(ctx context.Context, o
 }
 
 func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	defer r.Readier.Done(&gatewayv1alpha2.TLSRoute{}, req.NamespacedName)
-	tr := new(gatewayv1alpha2.TLSRoute)
+	defer r.Readier.Done(&gatewayv1.TLSRoute{}, req.NamespacedName)
+	tr := new(gatewayv1.TLSRoute)
 	if err := r.Get(ctx, req.NamespacedName, tr); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			tr.Namespace = req.Namespace
@@ -250,7 +248,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 			tr.TypeMeta = metav1.TypeMeta{
 				Kind:       types.KindTLSRoute,
-				APIVersion: gatewayv1alpha2.GroupVersion.String(),
+				APIVersion: gatewayv1.GroupVersion.String(),
 			}
 
 			if err := r.Provider.Delete(ctx, tr); err != nil {
@@ -331,9 +329,9 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	r.Updater.Update(status.Update{
 		NamespacedName: utils.NamespacedName(tr),
-		Resource:       &gatewayv1alpha2.TLSRoute{},
+		Resource:       &gatewayv1.TLSRoute{},
 		Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-			t, ok := obj.(*gatewayv1alpha2.TLSRoute)
+			t, ok := obj.(*gatewayv1.TLSRoute)
 			if !ok {
 				err := fmt.Errorf("unsupported object type %T", obj)
 				panic(err)
@@ -353,7 +351,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
-func (r *TLSRouteReconciler) processTLSRoute(tctx *provider.TranslateContext, tlsRoute *gatewayv1alpha2.TLSRoute) error {
+func (r *TLSRouteReconciler) processTLSRoute(tctx *provider.TranslateContext, tlsRoute *gatewayv1.TLSRoute) error {
 	var terror error
 	for _, rule := range tlsRoute.Spec.Rules {
 		for _, backend := range rule.BackendRefs {
@@ -411,10 +409,10 @@ func (r *TLSRouteReconciler) processTLSRouteBackendRefs(tctx *provider.Translate
 		if trNN.Namespace != targetNN.Namespace {
 			if permitted := checkReferenceGrant(tctx,
 				r.Client,
-				v1beta1.ReferenceGrantFrom{
+				gatewayv1.ReferenceGrantFrom{
 					Group:     gatewayv1.GroupName,
 					Kind:      types.KindTLSRoute,
-					Namespace: v1beta1.Namespace(trNN.Namespace),
+					Namespace: gatewayv1.Namespace(trNN.Namespace),
 				},
 				gatewayv1.ObjectReference{
 					Group:     corev1.GroupName,
@@ -424,7 +422,7 @@ func (r *TLSRouteReconciler) processTLSRouteBackendRefs(tctx *provider.Translate
 				},
 			); !permitted {
 				terr = types.ReasonError{
-					Reason:  string(v1beta1.RouteReasonRefNotPermitted),
+					Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
 					Message: fmt.Sprintf("%s is in a different namespace than the TLSRoute %s and no ReferenceGrant allowing reference is configured", targetNN, trNN),
 				}
 				continue
@@ -467,23 +465,23 @@ func (r *TLSRouteReconciler) processTLSRouteBackendRefs(tctx *provider.Translate
 }
 
 func (r *TLSRouteReconciler) listTLSRoutesForReferenceGrant(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
-	grant, ok := obj.(*v1beta1.ReferenceGrant)
+	grant, ok := obj.(*gatewayv1.ReferenceGrant)
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to ReferenceGrant")
 		return nil
 	}
 
-	var tlsRouteList gatewayv1alpha2.TLSRouteList
+	var tlsRouteList gatewayv1.TLSRouteList
 	if err := r.List(ctx, &tlsRouteList); err != nil {
 		r.Log.Error(err, "failed to list tlsroutes for reference ReferenceGrant", "ReferenceGrant", k8stypes.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()})
 		return nil
 	}
 
 	for _, tlsRoute := range tlsRouteList.Items {
-		tr := v1beta1.ReferenceGrantFrom{
+		tr := gatewayv1.ReferenceGrantFrom{
 			Group:     gatewayv1.GroupName,
 			Kind:      types.KindTLSRoute,
-			Namespace: v1beta1.Namespace(tlsRoute.GetNamespace()),
+			Namespace: gatewayv1.Namespace(tlsRoute.GetNamespace()),
 		}
 		for _, from := range grant.Spec.From {
 			if from == tr {
@@ -508,7 +506,7 @@ func (r *TLSRouteReconciler) listTLSRoutesByServiceRef(ctx context.Context, obj 
 	namespace := endpointSlice.GetNamespace()
 	serviceName := endpointSlice.Labels[discoveryv1.LabelServiceName]
 
-	trList := &gatewayv1alpha2.TLSRouteList{}
+	trList := &gatewayv1.TLSRouteList{}
 	if err := r.List(ctx, trList, client.MatchingFields{
 		indexer.ServiceIndexRef: indexer.GenIndexKey(namespace, serviceName),
 	}); err != nil {

--- a/internal/controller/udproute_controller.go
+++ b/internal/controller/udproute_controller.go
@@ -35,8 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
@@ -68,7 +66,7 @@ type UDPRouteReconciler struct { //nolint:revive
 func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	bdr := ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1alpha2.UDPRoute{}).
+		For(&gatewayv1.UDPRoute{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Watches(&discoveryv1.EndpointSlice{},
 			handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesByServiceRef),
@@ -113,7 +111,7 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	if GetEnableReferenceGrant() {
-		bdr.Watches(&v1beta1.ReferenceGrant{},
+		bdr.Watches(&gatewayv1.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForReferenceGrant),
 			builder.WithPredicates(referenceGrantPredicates(KindUDPRoute)),
 		)
@@ -129,7 +127,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForBackendTrafficPolicy(ctx context.Co
 		return nil
 	}
 
-	udprouteList := []gatewayv1alpha2.UDPRoute{}
+	udprouteList := []gatewayv1.UDPRoute{}
 	for _, targetRef := range policy.Spec.TargetRefs {
 		service := &corev1.Service{}
 		if err := r.Get(ctx, client.ObjectKey{
@@ -141,7 +139,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForBackendTrafficPolicy(ctx context.Co
 			}
 			continue
 		}
-		udprList := &gatewayv1alpha2.UDPRouteList{}
+		udprList := &gatewayv1.UDPRouteList{}
 		if err := r.List(ctx, udprList, client.MatchingFields{
 			indexer.ServiceIndexRef: indexer.GenIndexKey(policy.Namespace, string(targetRef.Name)),
 		}); err != nil {
@@ -175,7 +173,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGateway(ctx context.Context, obj cl
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to Gateway")
 	}
-	udprList := &gatewayv1alpha2.UDPRouteList{}
+	udprList := &gatewayv1.UDPRouteList{}
 	if err := r.List(ctx, udprList, client.MatchingFields{
 		indexer.ParentRefs: indexer.GenIndexKey(gateway.Namespace, gateway.Name),
 	}); err != nil {
@@ -219,7 +217,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGatewayProxy(ctx context.Context, o
 
 	// for each gateway, find all UDPRoute resources that reference it
 	for _, gateway := range gatewayList.Items {
-		udpRouteList := &gatewayv1alpha2.UDPRouteList{}
+		udpRouteList := &gatewayv1.UDPRouteList{}
 		if err := r.List(ctx, udpRouteList, client.MatchingFields{
 			indexer.ParentRefs: indexer.GenIndexKey(gateway.Namespace, gateway.Name),
 		}); err != nil {
@@ -241,8 +239,8 @@ func (r *UDPRouteReconciler) listUDPRoutesForGatewayProxy(ctx context.Context, o
 }
 
 func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	defer r.Readier.Done(&gatewayv1alpha2.UDPRoute{}, req.NamespacedName)
-	tr := new(gatewayv1alpha2.UDPRoute)
+	defer r.Readier.Done(&gatewayv1.UDPRoute{}, req.NamespacedName)
+	tr := new(gatewayv1.UDPRoute)
 	if err := r.Get(ctx, req.NamespacedName, tr); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			tr.Namespace = req.Namespace
@@ -250,7 +248,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 			tr.TypeMeta = metav1.TypeMeta{
 				Kind:       KindUDPRoute,
-				APIVersion: gatewayv1alpha2.GroupVersion.String(),
+				APIVersion: gatewayv1.GroupVersion.String(),
 			}
 
 			if err := r.Provider.Delete(ctx, tr); err != nil {
@@ -339,9 +337,9 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	r.Updater.Update(status.Update{
 		NamespacedName: utils.NamespacedName(tr),
-		Resource:       &gatewayv1alpha2.UDPRoute{},
+		Resource:       &gatewayv1.UDPRoute{},
 		Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-			t, ok := obj.(*gatewayv1alpha2.UDPRoute)
+			t, ok := obj.(*gatewayv1.UDPRoute)
 			if !ok {
 				err := fmt.Errorf("unsupported object type %T", obj)
 				panic(err)
@@ -361,7 +359,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
-func (r *UDPRouteReconciler) processUDPRoute(tctx *provider.TranslateContext, udpRoute *gatewayv1alpha2.UDPRoute) error {
+func (r *UDPRouteReconciler) processUDPRoute(tctx *provider.TranslateContext, udpRoute *gatewayv1.UDPRoute) error {
 	var terror error
 	for _, rule := range udpRoute.Spec.Rules {
 		for _, backend := range rule.BackendRefs {
@@ -419,10 +417,10 @@ func (r *UDPRouteReconciler) processUDPRouteBackendRefs(tctx *provider.Translate
 		if trNN.Namespace != targetNN.Namespace {
 			if permitted := checkReferenceGrant(tctx,
 				r.Client,
-				v1beta1.ReferenceGrantFrom{
+				gatewayv1.ReferenceGrantFrom{
 					Group:     gatewayv1.GroupName,
 					Kind:      KindUDPRoute,
-					Namespace: v1beta1.Namespace(trNN.Namespace),
+					Namespace: gatewayv1.Namespace(trNN.Namespace),
 				},
 				gatewayv1.ObjectReference{
 					Group:     corev1.GroupName,
@@ -432,7 +430,7 @@ func (r *UDPRouteReconciler) processUDPRouteBackendRefs(tctx *provider.Translate
 				},
 			); !permitted {
 				terr = types.ReasonError{
-					Reason:  string(v1beta1.RouteReasonRefNotPermitted),
+					Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
 					Message: fmt.Sprintf("%s is in a different namespace than the UDPRoute %s and no ReferenceGrant allowing reference is configured", targetNN, trNN),
 				}
 				continue
@@ -475,23 +473,23 @@ func (r *UDPRouteReconciler) processUDPRouteBackendRefs(tctx *provider.Translate
 }
 
 func (r *UDPRouteReconciler) listUDPRoutesForReferenceGrant(ctx context.Context, obj client.Object) (requests []reconcile.Request) {
-	grant, ok := obj.(*v1beta1.ReferenceGrant)
+	grant, ok := obj.(*gatewayv1.ReferenceGrant)
 	if !ok {
 		r.Log.Error(fmt.Errorf("unexpected object type"), "failed to convert object to ReferenceGrant")
 		return nil
 	}
 
-	var udpRouteList gatewayv1alpha2.UDPRouteList
+	var udpRouteList gatewayv1.UDPRouteList
 	if err := r.List(ctx, &udpRouteList); err != nil {
 		r.Log.Error(err, "failed to list udproutes for reference ReferenceGrant", "ReferenceGrant", k8stypes.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()})
 		return nil
 	}
 
 	for _, udpRoute := range udpRouteList.Items {
-		tr := v1beta1.ReferenceGrantFrom{
+		tr := gatewayv1.ReferenceGrantFrom{
 			Group:     gatewayv1.GroupName,
 			Kind:      KindUDPRoute,
-			Namespace: v1beta1.Namespace(udpRoute.GetNamespace()),
+			Namespace: gatewayv1.Namespace(udpRoute.GetNamespace()),
 		}
 		for _, from := range grant.Spec.From {
 			if from == tr {
@@ -516,7 +514,7 @@ func (r *UDPRouteReconciler) listUDPRoutesByServiceRef(ctx context.Context, obj 
 	namespace := endpointSlice.GetNamespace()
 	serviceName := endpointSlice.Labels[discoveryv1.LabelServiceName]
 
-	trList := &gatewayv1alpha2.UDPRouteList{}
+	trList := &gatewayv1.UDPRouteList{}
 	if err := r.List(ctx, trList, client.MatchingFields{
 		indexer.ServiceIndexRef: indexer.GenIndexKey(namespace, serviceName),
 	}); err != nil {

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -46,8 +46,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -661,11 +659,11 @@ func routeHostnamesIntersectsWithListenerHostname(route client.Object, listener 
 	switch r := route.(type) {
 	case *gatewayv1.HTTPRoute:
 		return listenerHostnameIntersectWithRouteHostnames(listener, r.Spec.Hostnames)
-	case *gatewayv1alpha2.TCPRoute, *gatewayv1alpha2.UDPRoute:
+	case *gatewayv1.TCPRoute, *gatewayv1.UDPRoute:
 		return true // TCPRoute and UDPRoute don't have Hostnames to match
 	case *gatewayv1.GRPCRoute:
 		return listenerHostnameIntersectWithRouteHostnames(listener, r.Spec.Hostnames)
-	case *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.TLSRoute:
 		return listenerHostnameIntersectWithRouteHostnames(listener, r.Spec.Hostnames)
 	default:
 		return false
@@ -831,15 +829,15 @@ func routeMatchesListenerType(route client.Object, listener gatewayv1.Listener) 
 				return false, nil
 			}
 		}
-	case *gatewayv1alpha2.TCPRoute:
+	case *gatewayv1.TCPRoute:
 		if listener.Protocol != gatewayv1.TCPProtocolType {
 			return false, nil
 		}
-	case *gatewayv1alpha2.UDPRoute:
+	case *gatewayv1.UDPRoute:
 		if listener.Protocol != gatewayv1.UDPProtocolType {
 			return false, nil
 		}
-	case *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.TLSRoute:
 		if listener.Protocol != gatewayv1.TLSProtocolType {
 			return false, nil
 		}
@@ -873,11 +871,11 @@ func getAttachedRoutesForListener(ctx context.Context, mgrc client.Client, gatew
 			case types.KindGRPCRoute:
 				routeList = append(routeList, &gatewayv1.GRPCRouteList{})
 			case types.KindTCPRoute:
-				routeList = append(routeList, &gatewayv1alpha2.TCPRouteList{})
+				routeList = append(routeList, &gatewayv1.TCPRouteList{})
 			case types.KindUDPRoute:
-				routeList = append(routeList, &gatewayv1alpha2.UDPRouteList{})
+				routeList = append(routeList, &gatewayv1.UDPRouteList{})
 			case types.KindTLSRoute:
-				routeList = append(routeList, &gatewayv1alpha2.TLSRouteList{})
+				routeList = append(routeList, &gatewayv1.TLSRouteList{})
 			}
 		}
 	} else {
@@ -885,11 +883,11 @@ func getAttachedRoutesForListener(ctx context.Context, mgrc client.Client, gatew
 		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
 			routeList = append(routeList, &gatewayv1.HTTPRouteList{}, &gatewayv1.GRPCRouteList{})
 		case gatewayv1.TCPProtocolType:
-			routeList = append(routeList, &gatewayv1alpha2.TCPRouteList{})
+			routeList = append(routeList, &gatewayv1.TCPRouteList{})
 		case gatewayv1.UDPProtocolType:
-			routeList = append(routeList, &gatewayv1alpha2.UDPRouteList{})
+			routeList = append(routeList, &gatewayv1.UDPRouteList{})
 		case gatewayv1.TLSProtocolType:
-			routeList = append(routeList, &gatewayv1alpha2.TLSRouteList{})
+			routeList = append(routeList, &gatewayv1.TLSRouteList{})
 		}
 	}
 
@@ -1064,10 +1062,10 @@ func getListenerStatus(
 				}
 				if permitted := checkReferenceGrant(ctx,
 					mrgc,
-					v1beta1.ReferenceGrantFrom{
+					gatewayv1.ReferenceGrantFrom{
 						Group:     gatewayv1.GroupName,
 						Kind:      KindGateway,
-						Namespace: v1beta1.Namespace(gateway.Namespace),
+						Namespace: gatewayv1.Namespace(gateway.Namespace),
 					},
 					gatewayv1.ObjectReference{
 						Group:     corev1.GroupName,
@@ -1185,10 +1183,10 @@ func validateListenerFrontendValidation(
 		}
 		if permitted := checkReferenceGrant(ctx,
 			mrgc,
-			v1beta1.ReferenceGrantFrom{
+			gatewayv1.ReferenceGrantFrom{
 				Group:     gatewayv1.GroupName,
 				Kind:      KindGateway,
-				Namespace: v1beta1.Namespace(gateway.Namespace),
+				Namespace: gatewayv1.Namespace(gateway.Namespace),
 			},
 			gatewayv1.ObjectReference{
 				Group:     corev1.GroupName,
@@ -1504,7 +1502,7 @@ func isTLSSecretValid(secret *corev1.Secret) (string, bool) {
 
 func referenceGrantPredicates(kind gatewayv1.Kind) predicate.Funcs {
 	var filter = func(obj client.Object) bool {
-		grant, ok := obj.(*v1beta1.ReferenceGrant)
+		grant, ok := obj.(*gatewayv1.ReferenceGrant)
 		if !ok {
 			return false
 		}
@@ -1522,7 +1520,7 @@ func referenceGrantPredicates(kind gatewayv1.Kind) predicate.Funcs {
 	return predicates
 }
 
-func checkReferenceGrant(ctx context.Context, cli client.Client, obj v1beta1.ReferenceGrantFrom, ref gatewayv1.ObjectReference) bool {
+func checkReferenceGrant(ctx context.Context, cli client.Client, obj gatewayv1.ReferenceGrantFrom, ref gatewayv1.ObjectReference) bool {
 	if ref.Namespace == nil || *ref.Namespace == obj.Namespace {
 		return true
 	}
@@ -1531,7 +1529,7 @@ func checkReferenceGrant(ctx context.Context, cli client.Client, obj v1beta1.Ref
 		return false
 	}
 
-	var grantList v1beta1.ReferenceGrantList
+	var grantList gatewayv1.ReferenceGrantList
 	if err := cli.List(ctx, &grantList, client.InNamespace(*ref.Namespace)); err != nil {
 		return false
 	}
@@ -1565,15 +1563,15 @@ func CheckConsumerSecretRef(ctx context.Context, cli client.Client, fromNamespac
 		return false, nil
 	}
 
-	var grantList v1beta1.ReferenceGrantList
+	var grantList gatewayv1.ReferenceGrantList
 	if err := cli.List(ctx, &grantList, client.InNamespace(secretNN.Namespace)); err != nil {
 		return false, err
 	}
 
-	from := v1beta1.ReferenceGrantFrom{
-		Group:     v1beta1.Group(v1alpha1.GroupVersion.Group),
+	from := gatewayv1.ReferenceGrantFrom{
+		Group:     gatewayv1.Group(v1alpha1.GroupVersion.Group),
 		Kind:      types.KindConsumer,
-		Namespace: v1beta1.Namespace(fromNamespace),
+		Namespace: gatewayv1.Namespace(fromNamespace),
 	}
 	for _, grant := range grantList.Items {
 		for _, f := range grant.Spec.From {

--- a/internal/controller/utils_listenerstatus_test.go
+++ b/internal/controller/utils_listenerstatus_test.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/internal/controller/indexer"
 )
@@ -84,7 +83,7 @@ func TestGetListenerStatus_Conflicted(t *testing.T) {
 				WithObjects(newParentRefGatewayClass(), gw).
 				// Counting attached routes goes through the parentRefs index; no
 				// route exists here, only the index has to be known.
-				WithIndex(&gatewayv1alpha2.TLSRoute{}, indexer.ParentRefs,
+				WithIndex(&gatewayv1.TLSRoute{}, indexer.ParentRefs,
 					func(client.Object) []string { return nil }).
 				Build()
 

--- a/internal/controller/utils_parentref_test.go
+++ b/internal/controller/utils_parentref_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 )
@@ -38,7 +37,6 @@ func parentRefTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, gatewayv1.Install(scheme))
-	require.NoError(t, gatewayv1alpha2.Install(scheme))
 	return scheme
 }
 
@@ -217,7 +215,7 @@ func TestParseRouteParentRefs_ConflictingTLSModePort(t *testing.T) {
 			},
 		},
 	}
-	route := &gatewayv1alpha2.TLSRoute{
+	route := &gatewayv1.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "tr"},
 	}
 	cli := fake.NewClientBuilder().WithScheme(scheme).

--- a/internal/manager/controllers.go
+++ b/internal/manager/controllers.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -158,7 +157,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 				Updater:  updater,
 				Readier:  readier,
 			},
-			&gatewayv1alpha2.TCPRoute{}: &controller.TCPRouteReconciler{
+			&gatewayv1.TCPRoute{}: &controller.TCPRouteReconciler{
 				Client:   mgr.GetClient(),
 				Scheme:   mgr.GetScheme(),
 				Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName(types.KindTCPRoute),
@@ -166,7 +165,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 				Updater:  updater,
 				Readier:  readier,
 			},
-			&gatewayv1alpha2.UDPRoute{}: &controller.UDPRouteReconciler{
+			&gatewayv1.UDPRoute{}: &controller.UDPRouteReconciler{
 				Client:   mgr.GetClient(),
 				Scheme:   mgr.GetScheme(),
 				Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName(types.KindUDPRoute),
@@ -182,7 +181,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager, pro provider.Pro
 				Updater:  updater,
 				Readier:  readier,
 			},
-			&gatewayv1alpha2.TLSRoute{}: &controller.TLSRouteReconciler{
+			&gatewayv1.TLSRoute{}: &controller.TLSRouteReconciler{
 				Client:   mgr.GetClient(),
 				Scheme:   mgr.GetScheme(),
 				Log:      ctrl.LoggerFrom(ctx).WithName("controllers").WithName(types.KindTLSRoute),
@@ -373,9 +372,9 @@ func registerGatewayAPIForReadinessGVK(mgr manager.Manager, readier readiness.Re
 	resources := []client.Object{
 		&gatewayv1.HTTPRoute{},
 		&gatewayv1.GRPCRoute{},
-		&gatewayv1alpha2.TCPRoute{},
-		&gatewayv1alpha2.UDPRoute{},
-		&gatewayv1alpha2.TLSRoute{},
+		&gatewayv1.TCPRoute{},
+		&gatewayv1.UDPRoute{},
+		&gatewayv1.TLSRoute{},
 	}
 	gvks := make([]schema.GroupVersionKind, 0, len(resources))
 	for _, resource := range resources {

--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -34,8 +34,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -60,16 +58,10 @@ func init() {
 	if err := gatewayv1.Install(scheme); err != nil {
 		panic(err)
 	}
-	if err := gatewayv1alpha2.Install(scheme); err != nil {
-		panic(err)
-	}
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 	if err := apiv2.AddToScheme(scheme); err != nil {
-		panic(err)
-	}
-	if err := v1beta1.Install(scheme); err != nil {
 		panic(err)
 	}
 	if err := networkingv1beta1.AddToScheme(scheme); err != nil {
@@ -249,13 +241,13 @@ func Run(ctx context.Context, logger logr.Logger) error {
 		setupLog.Info("Gateway API is disabled, skipping the ReferenceGrants check")
 	} else {
 		setupLog.Info("check ReferenceGrants is enabled")
-		if hasReferenceGrant, err = utils.HasAPIResource(mgr, &v1beta1.ReferenceGrant{}); err != nil {
+		if hasReferenceGrant, err = utils.HasAPIResource(mgr, &gatewayv1.ReferenceGrant{}); err != nil {
 			setupLog.Error(err, "unable to detect whether ReferenceGrants is installed")
 			return err
 		}
 		if !hasReferenceGrant {
 			setupLog.Info("CRD ReferenceGrants is not installed, cross-namespace references will be rejected",
-				"gvk", utils.FormatGVK(&v1beta1.ReferenceGrant{}))
+				"gvk", utils.FormatGVK(&gatewayv1.ReferenceGrant{}))
 		}
 	}
 	controller.SetEnableReferenceGrant(hasReferenceGrant)

--- a/internal/provider/api7ee/provider.go
+++ b/internal/provider/api7ee/provider.go
@@ -28,7 +28,6 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
@@ -111,13 +110,13 @@ func (d *api7eeProvider) Update(ctx context.Context, tctx *provider.TranslateCon
 	case *gatewayv1.HTTPRoute:
 		result, err = d.translator.TranslateHTTPRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, "service")
-	case *gatewayv1alpha2.TCPRoute:
+	case *gatewayv1.TCPRoute:
 		result, err = d.translator.TranslateTCPRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
-	case *gatewayv1alpha2.UDPRoute:
+	case *gatewayv1.UDPRoute:
 		result, err = d.translator.TranslateUDPRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
-	case *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.TLSRoute:
 		result, err = d.translator.TranslateTLSRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
 	case *gatewayv1.GRPCRoute:
@@ -201,7 +200,7 @@ func (d *api7eeProvider) Delete(ctx context.Context, obj client.Object) error {
 	var resourceTypes []string
 	var labels map[string]string
 	switch obj.(type) {
-	case *gatewayv1.HTTPRoute, *apiv2.ApisixRoute, *gatewayv1.GRPCRoute, *gatewayv1alpha2.TCPRoute, *gatewayv1alpha2.UDPRoute, *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.HTTPRoute, *apiv2.ApisixRoute, *gatewayv1.GRPCRoute, *gatewayv1.TCPRoute, *gatewayv1.UDPRoute, *gatewayv1.TLSRoute:
 		resourceTypes = append(resourceTypes, "service")
 		labels = label.GenLabel(obj)
 	case *gatewayv1.Gateway:

--- a/internal/provider/api7ee/status.go
+++ b/internal/provider/api7ee/status.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/label"
@@ -155,9 +154,9 @@ func (d *api7eeProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 		}
 		d.updater.Update(status.Update{
 			NamespacedName: nnk.NamespacedName(),
-			Resource:       &gatewayv1alpha2.UDPRoute{},
+			Resource:       &gatewayv1.UDPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-				cp := obj.(*gatewayv1alpha2.UDPRoute).DeepCopy()
+				cp := obj.(*gatewayv1.UDPRoute).DeepCopy()
 				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
@@ -191,9 +190,9 @@ func (d *api7eeProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 		}
 		d.updater.Update(status.Update{
 			NamespacedName: nnk.NamespacedName(),
-			Resource:       &gatewayv1alpha2.TCPRoute{},
+			Resource:       &gatewayv1.TCPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-				cp := obj.(*gatewayv1alpha2.TCPRoute).DeepCopy()
+				cp := obj.(*gatewayv1.TCPRoute).DeepCopy()
 				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
@@ -263,9 +262,9 @@ func (d *api7eeProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 		}
 		d.updater.Update(status.Update{
 			NamespacedName: nnk.NamespacedName(),
-			Resource:       &gatewayv1alpha2.TLSRoute{},
+			Resource:       &gatewayv1.TLSRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-				cp := obj.(*gatewayv1alpha2.TLSRoute).DeepCopy()
+				cp := obj.(*gatewayv1.TLSRoute).DeepCopy()
 				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {

--- a/internal/provider/apisix/provider.go
+++ b/internal/provider/apisix/provider.go
@@ -28,7 +28,6 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	adctypes "github.com/apache/apisix-ingress-controller/api/adc"
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
@@ -112,13 +111,13 @@ func (d *apisixProvider) Update(ctx context.Context, tctx *provider.TranslateCon
 	case *gatewayv1.HTTPRoute:
 		result, err = d.translator.TranslateHTTPRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
-	case *gatewayv1alpha2.TCPRoute:
+	case *gatewayv1.TCPRoute:
 		result, err = d.translator.TranslateTCPRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
-	case *gatewayv1alpha2.UDPRoute:
+	case *gatewayv1.UDPRoute:
 		result, err = d.translator.TranslateUDPRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
-	case *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.TLSRoute:
 		result, err = d.translator.TranslateTLSRoute(tctx, t.DeepCopy())
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
 	case *gatewayv1.GRPCRoute:
@@ -198,7 +197,7 @@ func (d *apisixProvider) Delete(ctx context.Context, obj client.Object) error {
 	var resourceTypes []string
 	var labels map[string]string
 	switch obj.(type) {
-	case *gatewayv1.HTTPRoute, *apiv2.ApisixRoute, *gatewayv1.GRPCRoute, *gatewayv1alpha2.TCPRoute, *gatewayv1alpha2.UDPRoute, *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.HTTPRoute, *apiv2.ApisixRoute, *gatewayv1.GRPCRoute, *gatewayv1.TCPRoute, *gatewayv1.UDPRoute, *gatewayv1.TLSRoute:
 		resourceTypes = append(resourceTypes, adctypes.TypeService)
 		labels = label.GenLabel(obj)
 	case *gatewayv1.Gateway:

--- a/internal/provider/apisix/status.go
+++ b/internal/provider/apisix/status.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/internal/controller/label"
@@ -156,9 +155,9 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 		}
 		d.updater.Update(status.Update{
 			NamespacedName: nnk.NamespacedName(),
-			Resource:       &gatewayv1alpha2.UDPRoute{},
+			Resource:       &gatewayv1.UDPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-				cp := obj.(*gatewayv1alpha2.UDPRoute).DeepCopy()
+				cp := obj.(*gatewayv1.UDPRoute).DeepCopy()
 				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
@@ -192,9 +191,9 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 		}
 		d.updater.Update(status.Update{
 			NamespacedName: nnk.NamespacedName(),
-			Resource:       &gatewayv1alpha2.TCPRoute{},
+			Resource:       &gatewayv1.TCPRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-				cp := obj.(*gatewayv1alpha2.TCPRoute).DeepCopy()
+				cp := obj.(*gatewayv1.TCPRoute).DeepCopy()
 				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {
@@ -264,9 +263,9 @@ func (d *apisixProvider) updateStatus(nnk types.NamespacedNameKind, condition me
 		}
 		d.updater.Update(status.Update{
 			NamespacedName: nnk.NamespacedName(),
-			Resource:       &gatewayv1alpha2.TLSRoute{},
+			Resource:       &gatewayv1.TLSRoute{},
 			Mutator: status.MutatorFunc(func(obj client.Object) client.Object {
-				cp := obj.(*gatewayv1alpha2.TLSRoute).DeepCopy()
+				cp := obj.(*gatewayv1.TLSRoute).DeepCopy()
 				condition.ObservedGeneration = cp.GetGeneration()
 				gatewayNs := cp.GetNamespace()
 				for i, ref := range cp.Status.Parents {

--- a/internal/types/k8s.go
+++ b/internal/types/k8s.go
@@ -26,8 +26,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	v2 "github.com/apache/apisix-ingress-controller/api/v2"
@@ -78,19 +76,19 @@ func KindOf(obj any) string {
 	switch obj.(type) {
 	case *gatewayv1.Gateway:
 		return KindGateway
-	case *gatewayv1alpha2.TCPRoute:
+	case *gatewayv1.TCPRoute:
 		return KindTCPRoute
-	case *gatewayv1alpha2.UDPRoute:
+	case *gatewayv1.UDPRoute:
 		return KindUDPRoute
 	case *gatewayv1.HTTPRoute:
 		return KindHTTPRoute
 	case *gatewayv1.GRPCRoute:
 		return KindGRPCRoute
-	case *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.TLSRoute:
 		return KindTLSRoute
 	case *gatewayv1.GatewayClass:
 		return KindGatewayClass
-	case *gatewayv1beta1.ReferenceGrant:
+	case *gatewayv1.ReferenceGrant:
 		return KindReferenceGrant
 	case *netv1.Ingress:
 		return KindIngress
@@ -156,10 +154,10 @@ func GvkOf(obj any) schema.GroupVersionKind {
 	switch obj.(type) {
 	case *gatewayv1.Gateway, *gatewayv1.HTTPRoute, *gatewayv1.GatewayClass, *gatewayv1.GRPCRoute:
 		return schema.GroupVersion(gatewayv1.GroupVersion).WithKind(kind)
-	case *gatewayv1alpha2.TCPRoute, *gatewayv1alpha2.UDPRoute, *gatewayv1alpha2.TLSRoute:
-		return schema.GroupVersion(gatewayv1alpha2.GroupVersion).WithKind(kind)
-	case *gatewayv1beta1.ReferenceGrant:
-		return schema.GroupVersion(gatewayv1beta1.GroupVersion).WithKind(kind)
+	case *gatewayv1.TCPRoute, *gatewayv1.UDPRoute, *gatewayv1.TLSRoute:
+		return schema.GroupVersion(gatewayv1.GroupVersion).WithKind(kind)
+	case *gatewayv1.ReferenceGrant:
+		return schema.GroupVersion(gatewayv1.GroupVersion).WithKind(kind)
 	case *netv1.Ingress, *netv1.IngressClass:
 		return netv1.SchemeGroupVersion.WithKind(kind)
 	case *netv1beta1.IngressClass:

--- a/internal/types/route_adapter.go
+++ b/internal/types/route_adapter.go
@@ -21,7 +21,6 @@ import (
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 type HTTPRouteAdapter struct {
@@ -53,7 +52,7 @@ func (r GRPCRouteAdapter) GetObject() client.Object {
 }
 
 type TCPRouteAdapter struct {
-	*gatewayv1alpha2.TCPRoute
+	*gatewayv1.TCPRoute
 }
 
 func (r TCPRouteAdapter) GetParentStatuses() []gatewayv1.RouteParentStatus {
@@ -68,7 +67,7 @@ func (r TCPRouteAdapter) GetObject() client.Object {
 }
 
 type UDPRouteAdapter struct {
-	*gatewayv1alpha2.UDPRoute
+	*gatewayv1.UDPRoute
 }
 
 func (r UDPRouteAdapter) GetParentStatuses() []gatewayv1.RouteParentStatus {
@@ -82,7 +81,7 @@ func (r UDPRouteAdapter) GetObject() client.Object {
 }
 
 type TLSRouteAdapter struct {
-	*gatewayv1alpha2.TLSRoute
+	*gatewayv1.TLSRoute
 }
 
 func (r TLSRouteAdapter) GetParentStatuses() []gatewayv1.RouteParentStatus {
@@ -108,11 +107,11 @@ func NewRouteAdapter(obj client.Object) RouteAdapter {
 		return &HTTPRouteAdapter{HTTPRoute: r}
 	case *gatewayv1.GRPCRoute:
 		return &GRPCRouteAdapter{GRPCRoute: r}
-	case *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.TLSRoute:
 		return &TLSRouteAdapter{TLSRoute: r}
-	case *gatewayv1alpha2.TCPRoute:
+	case *gatewayv1.TCPRoute:
 		return &TCPRouteAdapter{TCPRoute: r}
-	case *gatewayv1alpha2.UDPRoute:
+	case *gatewayv1.UDPRoute:
 		return &UDPRouteAdapter{UDPRoute: r}
 	default:
 		return nil
@@ -129,16 +128,16 @@ func NewRouteListAdapter(objList client.ObjectList) []RouteAdapter {
 		return lo.Map(r.Items, func(item gatewayv1.GRPCRoute, _ int) RouteAdapter {
 			return &GRPCRouteAdapter{GRPCRoute: &item}
 		})
-	case *gatewayv1alpha2.TLSRouteList:
-		return lo.Map(r.Items, func(item gatewayv1alpha2.TLSRoute, _ int) RouteAdapter {
+	case *gatewayv1.TLSRouteList:
+		return lo.Map(r.Items, func(item gatewayv1.TLSRoute, _ int) RouteAdapter {
 			return &TLSRouteAdapter{TLSRoute: &item}
 		})
-	case *gatewayv1alpha2.TCPRouteList:
-		return lo.Map(r.Items, func(item gatewayv1alpha2.TCPRoute, _ int) RouteAdapter {
+	case *gatewayv1.TCPRouteList:
+		return lo.Map(r.Items, func(item gatewayv1.TCPRoute, _ int) RouteAdapter {
 			return &TCPRouteAdapter{TCPRoute: &item}
 		})
-	case *gatewayv1alpha2.UDPRouteList:
-		return lo.Map(r.Items, func(item gatewayv1alpha2.UDPRoute, _ int) RouteAdapter {
+	case *gatewayv1.UDPRouteList:
+		return lo.Map(r.Items, func(item gatewayv1.UDPRoute, _ int) RouteAdapter {
 			return &UDPRouteAdapter{UDPRoute: &item}
 		})
 	default:

--- a/internal/webhook/v1/consumer_webhook_test.go
+++ b/internal/webhook/v1/consumer_webhook_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	apisixv1alpha1 "github.com/apache/apisix-ingress-controller/api/v1alpha1"
 	"github.com/apache/apisix-ingress-controller/internal/controller"
@@ -51,16 +50,16 @@ func enableReferenceGrant(t *testing.T) {
 }
 
 // consumerToSecretGrant permits Consumers in fromNS to reference Secrets in grantNS.
-func consumerToSecretGrant(grantNS, fromNS string) *v1beta1.ReferenceGrant {
-	return &v1beta1.ReferenceGrant{
+func consumerToSecretGrant(grantNS, fromNS string) *gatewayv1.ReferenceGrant {
+	return &gatewayv1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{Name: "allow-consumer", Namespace: grantNS},
-		Spec: v1beta1.ReferenceGrantSpec{
-			From: []v1beta1.ReferenceGrantFrom{{
-				Group:     v1beta1.Group(apisixv1alpha1.GroupVersion.Group),
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{
+				Group:     gatewayv1.Group(apisixv1alpha1.GroupVersion.Group),
 				Kind:      "Consumer",
-				Namespace: v1beta1.Namespace(fromNS),
+				Namespace: gatewayv1.Namespace(fromNS),
 			}},
-			To: []v1beta1.ReferenceGrantTo{{Group: "", Kind: "Secret"}},
+			To: []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Secret"}},
 		},
 	}
 }
@@ -72,7 +71,6 @@ func buildConsumerValidator(t *testing.T, objects ...runtime.Object) *ConsumerCu
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, apisixv1alpha1.AddToScheme(scheme))
 	require.NoError(t, gatewayv1.Install(scheme))
-	require.NoError(t, v1beta1.Install(scheme))
 
 	managed := []runtime.Object{
 		&gatewayv1.GatewayClass{
@@ -106,7 +104,6 @@ func buildConsumerValidatorWithInterceptor(t *testing.T, funcs interceptor.Funcs
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, apisixv1alpha1.AddToScheme(scheme))
 	require.NoError(t, gatewayv1.Install(scheme))
-	require.NoError(t, v1beta1.Install(scheme))
 
 	managed := []runtime.Object{
 		&gatewayv1.GatewayClass{
@@ -278,7 +275,7 @@ func TestConsumerValidator_CrossNamespaceSecretGrantLookupError(t *testing.T) {
 	validator := buildConsumerValidatorWithInterceptor(t,
 		interceptor.Funcs{
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-				if _, ok := list.(*v1beta1.ReferenceGrantList); ok {
+				if _, ok := list.(*gatewayv1.ReferenceGrantList); ok {
 					return apierrors.NewInternalError(fmt.Errorf("api server unavailable"))
 				}
 				return c.List(ctx, list, opts...)

--- a/internal/webhook/v1/ownership.go
+++ b/internal/webhook/v1/ownership.go
@@ -20,7 +20,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
@@ -61,14 +60,14 @@ func isGRPCRouteManaged(ctx context.Context, c client.Client, route *gatewayv1.G
 	return routeReferencesManagedGateway(ctx, c, route.Spec.ParentRefs, route.Namespace)
 }
 
-func isTCPRouteManaged(ctx context.Context, c client.Client, route *gatewayv1alpha2.TCPRoute) (bool, error) {
+func isTCPRouteManaged(ctx context.Context, c client.Client, route *gatewayv1.TCPRoute) (bool, error) {
 	if route == nil {
 		return false, nil
 	}
 	return routeReferencesManagedGateway(ctx, c, route.Spec.ParentRefs, route.Namespace)
 }
 
-func isUDPRouteManaged(ctx context.Context, c client.Client, route *gatewayv1alpha2.UDPRoute) (bool, error) {
+func isUDPRouteManaged(ctx context.Context, c client.Client, route *gatewayv1.UDPRoute) (bool, error) {
 	if route == nil {
 		return false, nil
 	}

--- a/internal/webhook/v1/tcproute_webhook.go
+++ b/internal/webhook/v1/tcproute_webhook.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 	"github.com/apache/apisix-ingress-controller/internal/webhook/v1/reference"
@@ -35,12 +35,12 @@ import (
 var tcpRouteLog = logf.Log.WithName("tcproute-resource")
 
 func SetupTCPRouteWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr, &gatewayv1alpha2.TCPRoute{}).
+	return ctrl.NewWebhookManagedBy(mgr, &gatewayv1.TCPRoute{}).
 		WithCustomValidator(NewTCPRouteCustomValidator(mgr.GetClient())).
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/validate-gateway-networking-k8s-io-v1alpha2-tcproute,mutating=false,failurePolicy=fail,sideEffects=None,groups=gateway.networking.k8s.io,resources=tcproutes,verbs=create;update,versions=v1alpha2,name=vtcproute-v1alpha2.kb.io,admissionReviewVersions=v1,failurePolicy=Ignore
+// +kubebuilder:webhook:path=/validate-gateway-networking-k8s-io-v1-tcproute,mutating=false,failurePolicy=fail,sideEffects=None,groups=gateway.networking.k8s.io,resources=tcproutes,verbs=create;update,versions=v1,name=vtcproute-v1.kb.io,admissionReviewVersions=v1,failurePolicy=Ignore
 
 type TCPRouteCustomValidator struct {
 	Client  client.Client
@@ -57,7 +57,7 @@ func NewTCPRouteCustomValidator(c client.Client) *TCPRouteCustomValidator {
 }
 
 func (v *TCPRouteCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	route, ok := obj.(*gatewayv1alpha2.TCPRoute)
+	route, ok := obj.(*gatewayv1.TCPRoute)
 	if !ok {
 		return nil, fmt.Errorf("expected a TCPRoute object but got %T", obj)
 	}
@@ -75,7 +75,7 @@ func (v *TCPRouteCustomValidator) ValidateCreate(ctx context.Context, obj runtim
 }
 
 func (v *TCPRouteCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	route, ok := newObj.(*gatewayv1alpha2.TCPRoute)
+	route, ok := newObj.(*gatewayv1.TCPRoute)
 	if !ok {
 		return nil, fmt.Errorf("expected a TCPRoute object for the newObj but got %T", newObj)
 	}
@@ -96,7 +96,7 @@ func (*TCPRouteCustomValidator) ValidateDelete(context.Context, runtime.Object) 
 	return nil, nil
 }
 
-func (v *TCPRouteCustomValidator) collectWarnings(ctx context.Context, route *gatewayv1alpha2.TCPRoute) admission.Warnings {
+func (v *TCPRouteCustomValidator) collectWarnings(ctx context.Context, route *gatewayv1.TCPRoute) admission.Warnings {
 	serviceVisited := make(map[types.NamespacedName]struct{})
 	namespace := route.GetNamespace()
 
@@ -116,7 +116,7 @@ func (v *TCPRouteCustomValidator) collectWarnings(ctx context.Context, route *ga
 		})...)
 	}
 
-	addBackendRef := func(ns, name string, group *gatewayv1alpha2.Group, kind *gatewayv1alpha2.Kind) {
+	addBackendRef := func(ns, name string, group *gatewayv1.Group, kind *gatewayv1.Kind) {
 		if name == "" {
 			return
 		}

--- a/internal/webhook/v1/tcproute_webhook_test.go
+++ b/internal/webhook/v1/tcproute_webhook_test.go
@@ -27,7 +27,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 )
@@ -38,7 +37,6 @@ func buildTCPRouteValidator(t *testing.T, objects ...runtime.Object) *TCPRouteCu
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, gatewayv1.Install(scheme))
-	require.NoError(t, gatewayv1alpha2.Install(scheme))
 
 	managed := []runtime.Object{
 		&gatewayv1.GatewayClass{
@@ -61,19 +59,19 @@ func buildTCPRouteValidator(t *testing.T, objects ...runtime.Object) *TCPRouteCu
 }
 
 func TestTCPRouteCustomValidator_WarnsForMissingReferences(t *testing.T) {
-	route := &gatewayv1alpha2.TCPRoute{
+	route := &gatewayv1.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.TCPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.TCPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.TCPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.TCPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("missing-svc"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("missing-svc"),
 						},
 					},
 				},
@@ -96,19 +94,19 @@ func TestTCPRouteCustomValidator_NoWarningsWhenResourcesExist(t *testing.T) {
 
 	validator := buildTCPRouteValidator(t, objs...)
 
-	route := &gatewayv1alpha2.TCPRoute{
+	route := &gatewayv1.TCPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.TCPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.TCPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.TCPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.TCPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("backend"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("backend"),
 						},
 					},
 				},

--- a/internal/webhook/v1/udproute_webhook.go
+++ b/internal/webhook/v1/udproute_webhook.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	internaltypes "github.com/apache/apisix-ingress-controller/internal/types"
 	"github.com/apache/apisix-ingress-controller/internal/webhook/v1/reference"
@@ -35,12 +35,12 @@ import (
 var udpRouteLog = logf.Log.WithName("udproute-resource")
 
 func SetupUDPRouteWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr, &gatewayv1alpha2.UDPRoute{}).
+	return ctrl.NewWebhookManagedBy(mgr, &gatewayv1.UDPRoute{}).
 		WithCustomValidator(NewUDPRouteCustomValidator(mgr.GetClient())).
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/validate-gateway-networking-k8s-io-v1alpha2-udproute,mutating=false,failurePolicy=fail,sideEffects=None,groups=gateway.networking.k8s.io,resources=udproutes,verbs=create;update,versions=v1alpha2,name=vudproute-v1alpha2.kb.io,admissionReviewVersions=v1,failurePolicy=Ignore
+// +kubebuilder:webhook:path=/validate-gateway-networking-k8s-io-v1-udproute,mutating=false,failurePolicy=fail,sideEffects=None,groups=gateway.networking.k8s.io,resources=udproutes,verbs=create;update,versions=v1,name=vudproute-v1.kb.io,admissionReviewVersions=v1,failurePolicy=Ignore
 
 type UDPRouteCustomValidator struct {
 	Client  client.Client
@@ -57,7 +57,7 @@ func NewUDPRouteCustomValidator(c client.Client) *UDPRouteCustomValidator {
 }
 
 func (v *UDPRouteCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	route, ok := obj.(*gatewayv1alpha2.UDPRoute)
+	route, ok := obj.(*gatewayv1.UDPRoute)
 	if !ok {
 		return nil, fmt.Errorf("expected a UDPRoute object but got %T", obj)
 	}
@@ -75,7 +75,7 @@ func (v *UDPRouteCustomValidator) ValidateCreate(ctx context.Context, obj runtim
 }
 
 func (v *UDPRouteCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	route, ok := newObj.(*gatewayv1alpha2.UDPRoute)
+	route, ok := newObj.(*gatewayv1.UDPRoute)
 	if !ok {
 		return nil, fmt.Errorf("expected a UDPRoute object for the newObj but got %T", newObj)
 	}
@@ -96,7 +96,7 @@ func (*UDPRouteCustomValidator) ValidateDelete(context.Context, runtime.Object) 
 	return nil, nil
 }
 
-func (v *UDPRouteCustomValidator) collectWarnings(ctx context.Context, route *gatewayv1alpha2.UDPRoute) admission.Warnings {
+func (v *UDPRouteCustomValidator) collectWarnings(ctx context.Context, route *gatewayv1.UDPRoute) admission.Warnings {
 	serviceVisited := make(map[types.NamespacedName]struct{})
 	namespace := route.GetNamespace()
 
@@ -116,7 +116,7 @@ func (v *UDPRouteCustomValidator) collectWarnings(ctx context.Context, route *ga
 		})...)
 	}
 
-	addBackendRef := func(ns, name string, group *gatewayv1alpha2.Group, kind *gatewayv1alpha2.Kind) {
+	addBackendRef := func(ns, name string, group *gatewayv1.Group, kind *gatewayv1.Kind) {
 		if name == "" {
 			return
 		}

--- a/internal/webhook/v1/udproute_webhook_test.go
+++ b/internal/webhook/v1/udproute_webhook_test.go
@@ -27,7 +27,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/apache/apisix-ingress-controller/internal/controller/config"
 )
@@ -38,7 +37,6 @@ func buildUDPRouteValidator(t *testing.T, objects ...runtime.Object) *UDPRouteCu
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, gatewayv1.Install(scheme))
-	require.NoError(t, gatewayv1alpha2.Install(scheme))
 
 	managed := []runtime.Object{
 		&gatewayv1.GatewayClass{
@@ -61,19 +59,19 @@ func buildUDPRouteValidator(t *testing.T, objects ...runtime.Object) *UDPRouteCu
 }
 
 func TestUDPRouteCustomValidator_WarnsForMissingReferences(t *testing.T) {
-	route := &gatewayv1alpha2.UDPRoute{
+	route := &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.UDPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.UDPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.UDPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("missing-svc"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("missing-svc"),
 						},
 					},
 				},
@@ -96,19 +94,19 @@ func TestUDPRouteCustomValidator_NoWarningsWhenResourcesExist(t *testing.T) {
 
 	validator := buildUDPRouteValidator(t, objs...)
 
-	route := &gatewayv1alpha2.UDPRoute{
+	route := &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.UDPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.UDPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.UDPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("backend"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("backend"),
 						},
 					},
 				},
@@ -128,19 +126,19 @@ func TestUDPRouteCustomValidator_ValidateUpdate(t *testing.T) {
 
 	validator := buildUDPRouteValidator(t, objs...)
 
-	oldRoute := &gatewayv1alpha2.UDPRoute{
+	oldRoute := &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.UDPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.UDPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.UDPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("backend"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("backend"),
 						},
 					},
 				},
@@ -148,19 +146,19 @@ func TestUDPRouteCustomValidator_ValidateUpdate(t *testing.T) {
 		},
 	}
 
-	newRoute := &gatewayv1alpha2.UDPRoute{
+	newRoute := &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.UDPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.UDPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.UDPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("backend"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("backend"),
 						},
 					},
 				},
@@ -176,12 +174,12 @@ func TestUDPRouteCustomValidator_ValidateUpdate(t *testing.T) {
 func TestUDPRouteCustomValidator_ValidateDelete(t *testing.T) {
 	validator := buildUDPRouteValidator(t)
 
-	route := &gatewayv1alpha2.UDPRoute{
+	route := &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.UDPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
 		},
@@ -193,26 +191,26 @@ func TestUDPRouteCustomValidator_ValidateDelete(t *testing.T) {
 }
 
 func TestUDPRouteCustomValidator_CrossNamespaceBackendRefs(t *testing.T) {
-	otherNamespace := gatewayv1alpha2.Namespace("other")
+	otherNamespace := gatewayv1.Namespace("other")
 	objs := []runtime.Object{
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend", Namespace: "other"}},
 	}
 
 	validator := buildUDPRouteValidator(t, objs...)
 
-	route := &gatewayv1alpha2.UDPRoute{
+	route := &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.UDPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.UDPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.UDPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name:      gatewayv1alpha2.ObjectName("backend"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name:      gatewayv1.ObjectName("backend"),
 							Namespace: &otherNamespace,
 						},
 					},
@@ -235,29 +233,29 @@ func TestUDPRouteCustomValidator_MultipleBackendRefs(t *testing.T) {
 
 	validator := buildUDPRouteValidator(t, objs...)
 
-	route := &gatewayv1alpha2.UDPRoute{
+	route := &gatewayv1.UDPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
-		Spec: gatewayv1alpha2.UDPRouteSpec{
-			CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayv1alpha2.ParentReference{{
-					Name: gatewayv1alpha2.ObjectName("test-gateway"),
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: gatewayv1.ObjectName("test-gateway"),
 				}},
 			},
-			Rules: []gatewayv1alpha2.UDPRouteRule{{
-				BackendRefs: []gatewayv1alpha2.BackendRef{
+			Rules: []gatewayv1.UDPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("backend-1"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("backend-1"),
 						},
 					},
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("backend-2"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("backend-2"),
 						},
 					},
 					{
-						BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
-							Name: gatewayv1alpha2.ObjectName("missing-backend"),
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("missing-backend"),
 						},
 					},
 				},

--- a/pkg/utils/cluster_test.go
+++ b/pkg/utils/cluster_test.go
@@ -254,7 +254,7 @@ func newDiscoveryClient(t *testing.T, handler http.HandlerFunc) discovery.Discov
 // discovery client rather than a fake: only a definitive answer may resolve to
 // "absent", everything else must be an error.
 func TestHasAPIResource(t *testing.T) {
-	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Kind: "TCPRoute"}
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "TCPRoute"}
 
 	tests := []struct {
 		name      string
@@ -266,7 +266,7 @@ func TestHasAPIResource(t *testing.T) {
 			name: "kind served",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1alpha2",` +
+				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1",` +
 					`"resources":[{"name":"tcproutes","kind":"TCPRoute"}]}`))
 			},
 			wantFound: true,
@@ -275,7 +275,7 @@ func TestHasAPIResource(t *testing.T) {
 			name: "group/version served but kind missing",
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1alpha2",` +
+				_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"gateway.networking.k8s.io/v1",` +
 					`"resources":[{"name":"udproutes","kind":"UDPRoute"}]}`))
 			},
 		},

--- a/test/e2e/framework/manifests/webhook.yaml
+++ b/test/e2e/framework/manifests/webhook.yaml
@@ -230,12 +230,12 @@ webhooks:
         - ingressclasses
   failurePolicy: Fail
   sideEffects: None
-- name: vtcproute-v1alpha2.kb.io
+- name: vtcproute-v1.kb.io
   clientConfig:
     service:
       name: webhook-service
       namespace: {{ .Namespace }}
-      path: /validate-gateway-networking-k8s-io-v1alpha2-tcproute
+      path: /validate-gateway-networking-k8s-io-v1-tcproute
     caBundle: {{ .CABundle }}
   admissionReviewVersions:
     - v1
@@ -246,17 +246,17 @@ webhooks:
       apiGroups:
         - gateway.networking.k8s.io
       apiVersions:
-        - v1alpha2
+        - v1
       resources:
         - tcproutes
   failurePolicy: Fail
   sideEffects: None
-- name: vudproute-v1alpha2.kb.io
+- name: vudproute-v1.kb.io
   clientConfig:
     service:
       name: webhook-service
       namespace: {{ .Namespace }}
-      path: /validate-gateway-networking-k8s-io-v1alpha2-udproute
+      path: /validate-gateway-networking-k8s-io-v1-udproute
     caBundle: {{ .CABundle }}
   admissionReviewVersions:
     - v1
@@ -267,7 +267,7 @@ webhooks:
       apiGroups:
         - gateway.networking.k8s.io
       apiVersions:
-        - v1alpha2
+        - v1
       resources:
         - udproutes
   failurePolicy: Fail

--- a/test/e2e/gatewayapi/gateway.go
+++ b/test/e2e/gatewayapi/gateway.go
@@ -488,7 +488,7 @@ spec:
       port: 8080
 `
 		var tcpRouteSpec = `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: %s
@@ -502,7 +502,7 @@ spec:
       port: 80
 `
 		var udpRoute = `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: %s

--- a/test/e2e/gatewayapi/tcproute.go
+++ b/test/e2e/gatewayapi/tcproute.go
@@ -60,7 +60,7 @@ spec:
 `
 
 		var tcpRoute = `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-app-1
@@ -136,7 +136,7 @@ spec:
 `
 
 		var tcpRoute = `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-tls-upstream
@@ -224,7 +224,7 @@ spec:
 `
 
 		var tcpRoute = `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-l4policy

--- a/test/e2e/gatewayapi/tlsroute.go
+++ b/test/e2e/gatewayapi/tlsroute.go
@@ -58,7 +58,7 @@ spec:
       name: apisix-proxy-config
 `
 			tlsRoute = `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tls-route

--- a/test/e2e/gatewayapi/udproute.go
+++ b/test/e2e/gatewayapi/udproute.go
@@ -53,7 +53,7 @@ spec:
 `
 
 		var udpRoute = `
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-app-1

--- a/test/e2e/scaffold/k8s.go
+++ b/test/e2e/scaffold/k8s.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	apiv2 "github.com/apache/apisix-ingress-controller/api/v2"
 	"github.com/apache/apisix-ingress-controller/test/e2e/framework"
@@ -457,7 +456,6 @@ func (s *Scaffold) GetKubeClient() client.Client {
 		_ = apiv2.AddToScheme(scheme)
 		_ = corev1.AddToScheme(scheme)
 		_ = gatewayv1.Install(scheme)
-		_ = v1alpha2.Install(scheme)
 		cfg, err := clientcmd.BuildConfigFromFlags("", s.opts.Kubeconfig)
 		Expect(err).NotTo(HaveOccurred(), "building kubeconfig")
 		s.client, err = client.New(cfg, client.Options{Scheme: scheme})

--- a/test/e2e/webhook/helpers.go
+++ b/test/e2e/webhook/helpers.go
@@ -165,7 +165,7 @@ spec:
 func verifySimpleRouteMissingBackendWarnings(s *scaffold.Scaffold, tc simpleRouteWebhookTestCase) {
 	gatewayName := s.Namespace()
 	routeYAML := fmt.Sprintf(`
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: %s
 metadata:
   name: %s


### PR DESCRIPTION
Sync of [apache/apisix-ingress-controller#2839](https://github.com/apache/apisix-ingress-controller/pull/2839).

## Problem

Gateway API 1.6 promoted TCPRoute, UDPRoute and TLSRoute to `v1` and deprecated `v1alpha2`, but the controller still registers, watches, indexes and validates all three through `sigs.k8s.io/gateway-api/apis/v1alpha2`. Every informer re-list logs:

```
Warning: The v1alpha2 version of TCPRoute has been deprecated and will be removed in a future release of the API. Please upgrade to v1.
```

That warning is the visible half. The real problem is that in the **1.6 standard channel** CRDs, `v1alpha2` is `served: false`:

| CRD | v1 | v1alpha2 (standard) | v1alpha2 (experimental) |
| --- | --- | --- | --- |
| tcproutes | served, storage | **not served** | served, deprecated |
| udproutes | served, storage | **not served** | served, deprecated |
| tlsroutes | served, storage | **not served** | served, deprecated |

So for anyone installing the standard channel, `HasAPIResource` in `setupGatewayAPIControllers` finds nothing, and the TCPRoute, UDPRoute and TLSRoute reconcilers are silently skipped — L4 routing does not work at all. Our `make install-gateway-api` installs the experimental channel, which still serves `v1alpha2`, which is why CI never caught this. Envoy Gateway hit the identical failure with TLSRoute: [envoyproxy/gateway#8326](https://github.com/envoyproxy/gateway/issues/8326).

## Solution

Switch every reference to `apis/v1`:

- scheme registration (`internal/manager/run.go`) and the CRD probe (`internal/manager/controllers.go`)
- field indexers, the three reconcilers, the translator, the route adapters
- the status writers for **both** the APISIX and API7 EE providers
- the TCPRoute/UDPRoute validating webhooks — paths move from `/validate-gateway-networking-k8s-io-v1alpha2-*` to `-v1-*`, `config/webhook/manifests.yaml` is regenerated to match, and the hand-written e2e webhook manifest is synced

The `v1alpha2` rule and status types are already type aliases of their `v1` counterparts, so this is a version switch rather than a behavior change.

ReferenceGrant moves to `v1` as well. That one is *not* urgent — `v1beta1` is not deprecated and remains the storage version — but every symbol used from `apis/v1beta1` exists in `apis/v1`, so reading it through the version the API now leads with is free.

User manifests that still declare an older version keep working wherever the installed CRDs serve it, because the API server converts them before they reach the informer (the Gateway API CRDs use `conversion.strategy: None`, so it is a no-op version relabel). Examples, e2e manifests and the docs support table now use `v1`.

One schema difference worth noting: `v1` tightens `TCPRouteSpec.Rules` from `MaxItems=16` to `MaxItems=1`. The translator iterates rules and is unaffected, and every manifest in this repo already carries a single rule.

## Breaking change

L4 routing now requires **Gateway API 1.6 or later**, the first release that serves the `v1` versions of TCPRoute, UDPRoute and TLSRoute. `go.mod` and the Makefile are already on 1.6.0.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `make lint` — 0 issues
- `go test ./internal/... ./pkg/...` — all packages pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gateway API v1 support for TCPRoute, UDPRoute, TLSRoute, and ReferenceGrant resources across routing, policy, status, and authorization workflows.
  * Updated validating webhooks and webhook configurations to use Gateway API v1.
  * Updated examples and end-to-end scenarios to use stable API versions.

* **Documentation**
  * Documented Gateway API 1.6+ L4 routing requirements, compatibility notes, and migration guidance from deprecated versions.

* **Bug Fixes**
  * Improved compatibility with clusters serving Gateway API v1 resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->