### PR TITLE
fix: keep API7 synchronization active and correct defaults

### DIFF
--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -1,11 +1,11 @@
-log_level: "info"                               # The log level of the APISIX Ingress Controller.
-                                                # the default value is "info".
+log_level: "info"                               # The log level of the API7 Ingress Controller.
+                                                # The default value is "info".
 
-controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the APISIX Ingress Controller,
+controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the API7 Ingress Controller,
                                                           # which is used to identify the controller in the GatewayClass.
                                                           # The default value is "apisix.apache.org/apisix-ingress-controller".
-leader_election_id: "apisix-ingress-controller-leader" # The leader election ID for the APISIX Ingress Controller.
-                                                        # The default value is "apisix-ingress-controller-leader".
+leader_election_id: "apisix-ingress-gateway-leader"    # The leader election ID for the API7 Ingress Controller.
+                                                       # The default value is "apisix-ingress-gateway-leader".
 leader_election:
   lease_duration: 30s                   # lease_duration is the duration that non-leader candidates will wait
                                         # after observing a leadership renewal until attempting to acquire leadership of a
@@ -20,7 +20,7 @@ metrics_addr: ":8080"                   # The address the metrics endpoint binds
                                         # The default value is ":8080".
 
 enable_server: false                    # The debug API is behind this server which is disabled by default for security reasons.
-server_addr: "127.0.0.1:9092"           # Available endpoints: /debug can be used to debug in-memory state of translated adc configs to be synced with data plane.
+server_addr: "127.0.0.1:9092"           # Recommended local binding for the debug API. The binary default is ":9092".
 
 enable_http2: false                     # Whether to enable HTTP/2 for the server.
                                         # The default value is false.
@@ -50,8 +50,9 @@ listener_port_match_mode: "off"         # Mode for injecting server_port route v
 provider:
   type: "api7ee"
 
-  sync_period: 1h                       # The period between two consecutive syncs. The default value is 1 hour.
-                                        # If you want to disable the sync, set it to 0.
+  sync_period: 0s                       # The period between two consecutive syncs.
+                                        # The default value is 0 seconds, which disables periodic synchronization.
+                                        # Set it to a positive value to enable periodic synchronization.
   init_sync_delay: 20m                # The initial delay before the first sync, only used when the controller is started.
                                         # The default value is 20 minutes.
 

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -1,11 +1,11 @@
-log_level: "info"                               # The log level of the API7 Ingress Controller.
-                                                # The default value is "info".
+log_level: "info"                               # The log level of the APISIX Ingress Controller.
+                                                # the default value is "info".
 
-controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the API7 Ingress Controller,
+controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the APISIX Ingress Controller,
                                                           # which is used to identify the controller in the GatewayClass.
                                                           # The default value is "apisix.apache.org/apisix-ingress-controller".
-leader_election_id: "apisix-ingress-gateway-leader"    # The leader election ID for the API7 Ingress Controller.
-                                                       # The default value is "apisix-ingress-gateway-leader".
+leader_election_id: "apisix-ingress-controller-leader" # The leader election ID for the APISIX Ingress Controller.
+                                                        # The default value is "apisix-ingress-controller-leader".
 leader_election:
   lease_duration: 30s                   # lease_duration is the duration that non-leader candidates will wait
                                         # after observing a leadership renewal until attempting to acquire leadership of a
@@ -20,7 +20,7 @@ metrics_addr: ":8080"                   # The address the metrics endpoint binds
                                         # The default value is ":8080".
 
 enable_server: false                    # The debug API is behind this server which is disabled by default for security reasons.
-server_addr: "127.0.0.1:9092"           # Recommended local binding for the debug API. The binary default is ":9092".
+server_addr: "127.0.0.1:9092"           # Available endpoints: /debug can be used to debug in-memory state of translated adc configs to be synced with data plane.
 
 enable_http2: false                     # Whether to enable HTTP/2 for the server.
                                         # The default value is false.
@@ -50,10 +50,8 @@ listener_port_match_mode: "off"         # Mode for injecting server_port route v
 provider:
   type: "api7ee"
 
-  sync_period: 0s                       # The period between two consecutive syncs.
-                                        # The default value is 0 seconds, which disables periodic synchronization
-                                        # while event-driven synchronization and retries remain enabled.
-                                        # Set it to a positive value to enable periodic synchronization.
+  sync_period: 1h                       # The period between two consecutive syncs. The default value is 1 hour.
+                                        # If you want to disable the sync, set it to 0.
   init_sync_delay: 20m                # The initial delay before the first sync, only used when the controller is started.
                                         # The default value is 20 minutes.
 

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -51,7 +51,8 @@ provider:
   type: "api7ee"
 
   sync_period: 0s                       # The period between two consecutive syncs.
-                                        # The default value is 0 seconds, which disables periodic synchronization.
+                                        # The default value is 0 seconds, which disables periodic synchronization
+                                        # while event-driven synchronization and retries remain enabled.
                                         # Set it to a positive value to enable periodic synchronization.
   init_sync_delay: 20m                # The initial delay before the first sync, only used when the controller is started.
                                         # The default value is 20 minutes.

--- a/docs/en/latest/configure.md
+++ b/docs/en/latest/configure.md
@@ -1,11 +1,11 @@
 ---
 title: Configuration
 keywords:
-  - APISIX Ingress
-  - Apache APISIX
+  - API7 Ingress
+  - API7
   - Kubernetes Ingress
   - Gateway API
-description: Configuration of the APISIX Ingress Controller
+description: Configuration of the API7 Ingress Controller
 ---
 <!--
 #
@@ -26,20 +26,20 @@ description: Configuration of the APISIX Ingress Controller
 #
 -->
 
-The APISIX Ingress Controller is a Kubernetes Ingress Controller that implements the Gateway API. This document describes how to configure the APISIX Ingress Controller.
+The API7 Ingress Controller is a Kubernetes Ingress Controller that implements the Gateway API. This document describes how to configure the API7 Ingress Controller.
 
 ## Example
 
 ```yaml
-log_level: "info"                               # The log level of the APISIX Ingress Controller.
-                                                # the default value is "info".
+log_level: "info"                               # The log level of the API7 Ingress Controller.
+                                                # The default value is "info".
 
-controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the APISIX Ingress Controller,
+controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the API7 Ingress Controller,
                                                           # which is used to identify the controller in the GatewayClass.
                                                           # The default value is "apisix.apache.org/apisix-ingress-controller".
 
-leader_election_id: "apisix-ingress-controller-leader" # The leader election ID for the APISIX Ingress Controller.
-                                                        # The default value is "apisix-ingress-controller-leader".
+leader_election_id: "apisix-ingress-gateway-leader" # The leader election ID for the API7 Ingress Controller.
+                                                     # The default value is "apisix-ingress-gateway-leader".
 ```
 
 ### Controller Name

--- a/docs/en/latest/reference/configuration-file.md
+++ b/docs/en/latest/reference/configuration-file.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration File
 slug: /reference/apisix-ingress-controller/configuration-file
-description: Configure the APISIX Ingress Controller using the config.yaml file, including configurations such as log settings, leader election, metrics, and sync behavior.
+description: Configure the API7 Ingress Controller using config.yaml, including log settings, leader election, metrics, and synchronization behavior.
 ---
 
 <!--
@@ -23,21 +23,21 @@ description: Configure the APISIX Ingress Controller using the config.yaml file,
 #
 -->
 
-The APISIX Ingress Controller uses a configuration file `config.yaml` to define core settings such as log level, leader election behavior, metrics endpoints, and sync intervals.
+The API7 Ingress Controller uses a configuration file `config.yaml` to define core settings such as log level, leader election behavior, metrics endpoints, and synchronization intervals.
 
 Configurations are defined in a Kubernetes ConfigMap and mounted into the controller pod as a file at runtime. To apply changes, you can update the ConfigMap and restart the controller Deployment to reload the configurations.
 
-Below are all available configuration options, including their default values and usage:
+The example below shows binary defaults. Helm charts can render different values into the ConfigMap, so inspect the chart values and the generated ConfigMap when troubleshooting an installation.
 
 ```yaml
-log_level: "info"                               # The log level of the APISIX Ingress Controller.
+log_level: "info"                               # The log level of the API7 Ingress Controller.
                                                 # The default value is "info".
 
-controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the APISIX Ingress Controller,
+controller_name: apisix.apache.org/apisix-ingress-controller  # The controller name of the API7 Ingress Controller,
                                                               # which is used to identify the controller in the GatewayClass.
                                                               # The default value is "apisix.apache.org/apisix-ingress-controller".
-leader_election_id: "apisix-ingress-controller-leader"    # The leader election ID for the APISIX Ingress Controller.
-                                                          # The default value is "apisix-ingress-controller-leader".
+leader_election_id: "apisix-ingress-gateway-leader"       # The leader election ID for the API7 Ingress Controller.
+                                                          # The default value is "apisix-ingress-gateway-leader".
 leader_election:
   lease_duration: 30s                   # lease_duration is the duration that non-leader candidates will wait
                                         # after observing a leadership renewal until attempting to acquire leadership of a
@@ -51,7 +51,10 @@ leader_election:
 metrics_addr: ":8080"                   # The address the metrics endpoint binds to.
                                         # The default value is ":8080".
 
-server_addr: "127.0.0.1:9092"           # Available endpoints: /debug can be used to debug in-memory state of translated adc configs to be synced with data plane.
+enable_server: false                    # Whether to enable the debug API.
+                                        # The default value is false.
+server_addr: ":9092"                    # The address the debug API binds to.
+                                        # The default value is ":9092".
 
 enable_http2: false                     # Whether to enable HTTP/2 for the server.
                                         # The default value is false.
@@ -65,12 +68,18 @@ secure_metrics: false                   # The secure metrics configuration.
 exec_adc_timeout: 15s                   # The timeout for the ADC to execute.
                                         # The default value is 15 seconds.
 
+listener_port_match_mode: "off"         # Mode for injecting server_port route vars from Gateway listener ports.
+                                        # - "off": never inject server_port vars.
+                                        # - "auto": inject when parentRefs explicitly target listeners (sectionName/port) or when multiple listener ports are matched.
+                                        # - "explicit": inject only when parentRefs explicitly target listeners.
+                                        # The default value is "off".
+
 provider:
   type: "api7ee"                        # Provider type.
 
   sync_period: 0s                       # The period between two consecutive syncs.
-                                        # The default value is 0 seconds, which means the controller will not sync.
-                                        # If you want to enable the sync, set it to a positive value.
+                                        # The default value is 0 seconds, which disables periodic synchronization.
+                                        # Set it to a positive value to enable periodic synchronization.
   init_sync_delay: 20m                  # The initial delay before the first sync, only used when the controller is started.
                                         # The default value is 20 minutes.
 ```

--- a/docs/en/latest/reference/configuration-file.md
+++ b/docs/en/latest/reference/configuration-file.md
@@ -73,12 +73,17 @@ listener_port_match_mode: "off"         # Mode for injecting server_port route v
                                         # - "auto": inject when parentRefs explicitly target listeners (sectionName/port) or when multiple listener ports are matched.
                                         # - "explicit": inject only when parentRefs explicitly target listeners.
                                         # The default value is "off".
+                                        # server_port is the port the data plane accepted the connection on
+                                        # (node_listen), not the port declared on the Gateway listener. Only enable
+                                        # "auto"/"explicit" when those two coincide, otherwise routes bound to a
+                                        # listener via sectionName/port will never match.
 
 provider:
   type: "api7ee"                        # Provider type.
 
   sync_period: 0s                       # The period between two consecutive syncs.
-                                        # The default value is 0 seconds, which disables periodic synchronization.
+                                        # The default value is 0 seconds, which disables periodic synchronization
+                                        # while event-driven synchronization and retries remain enabled.
                                         # Set it to a positive value to enable periodic synchronization.
   init_sync_delay: 20m                  # The initial delay before the first sync, only used when the controller is started.
                                         # The default value is 20 minutes.

--- a/internal/provider/api7ee/provider.go
+++ b/internal/provider/api7ee/provider.go
@@ -246,16 +246,14 @@ func (d *api7eeProvider) Start(ctx context.Context) error {
 		retrier.Next()
 	}
 
-	initalSyncDelay := d.InitSyncDelay
-	if initalSyncDelay > 0 {
-		time.AfterFunc(initalSyncDelay, func() {
-			if err := d.sync(ctx); err != nil {
-				d.log.Error(err, "failed to sync for startup")
-				retrier.Next()
-				return
-			}
-			retrier.Reset()
-		})
+	var (
+		initSyncTimer *time.Timer
+		initSyncC     <-chan time.Time
+	)
+	if d.InitSyncDelay > 0 {
+		initSyncTimer = time.NewTimer(d.InitSyncDelay)
+		initSyncC = initSyncTimer.C
+		defer initSyncTimer.Stop()
 	}
 
 	var (
@@ -272,6 +270,8 @@ func (d *api7eeProvider) Start(ctx context.Context) error {
 		select {
 		case <-d.syncCh:
 		case <-retrier.C():
+		case <-initSyncC:
+			initSyncC = nil
 		case <-tickerC:
 		case <-ctx.Done():
 			return nil

--- a/internal/provider/api7ee/provider.go
+++ b/internal/provider/api7ee/provider.go
@@ -253,11 +253,15 @@ func (d *api7eeProvider) Start(ctx context.Context) error {
 		})
 	}
 
-	if d.SyncPeriod < 1 {
-		return nil
+	var (
+		ticker  *time.Ticker
+		tickerC <-chan time.Time
+	)
+	if d.SyncPeriod > 0 {
+		ticker = time.NewTicker(d.SyncPeriod)
+		tickerC = ticker.C
+		defer ticker.Stop()
 	}
-	ticker := time.NewTicker(d.SyncPeriod)
-	defer ticker.Stop()
 
 	retrier := common.NewRetrier(common.NewExponentialBackoff(RetryBaseDelay, RetryMaxDelay))
 
@@ -265,7 +269,7 @@ func (d *api7eeProvider) Start(ctx context.Context) error {
 		select {
 		case <-d.syncCh:
 		case <-retrier.C():
-		case <-ticker.C:
+		case <-tickerC:
 		case <-ctx.Done():
 			return nil
 		}

--- a/internal/provider/api7ee/provider.go
+++ b/internal/provider/api7ee/provider.go
@@ -67,6 +67,7 @@ type api7eeProvider struct {
 	startUpSync atomic.Bool
 
 	client *adcclient.Client
+	syncFn func(context.Context) error
 	log    logr.Logger
 }
 
@@ -236,11 +237,13 @@ func (d *api7eeProvider) Delete(ctx context.Context, obj client.Object) error {
 
 func (d *api7eeProvider) Start(ctx context.Context) error {
 	d.readier.WaitReady(ctx, 5*time.Minute)
+	retrier := common.NewRetrier(common.NewExponentialBackoff(RetryBaseDelay, RetryMaxDelay))
 
 	d.startUpSync.Store(true)
 	d.log.Info("Performing startup synchronization")
 	if err := d.sync(ctx); err != nil {
 		d.log.Error(err, "failed to sync for startup")
+		retrier.Next()
 	}
 
 	initalSyncDelay := d.InitSyncDelay
@@ -248,8 +251,10 @@ func (d *api7eeProvider) Start(ctx context.Context) error {
 		time.AfterFunc(initalSyncDelay, func() {
 			if err := d.sync(ctx); err != nil {
 				d.log.Error(err, "failed to sync for startup")
+				retrier.Next()
 				return
 			}
+			retrier.Reset()
 		})
 	}
 
@@ -262,8 +267,6 @@ func (d *api7eeProvider) Start(ctx context.Context) error {
 		tickerC = ticker.C
 		defer ticker.Stop()
 	}
-
-	retrier := common.NewRetrier(common.NewExponentialBackoff(RetryBaseDelay, RetryMaxDelay))
 
 	for {
 		select {
@@ -291,6 +294,9 @@ func (d *api7eeProvider) syncNotify() {
 }
 
 func (d *api7eeProvider) sync(ctx context.Context) error {
+	if d.syncFn != nil {
+		return d.syncFn(ctx)
+	}
 	statusesMap, err := d.client.Sync(ctx)
 	d.handleADCExecutionErrors(statusesMap)
 	return err

--- a/internal/provider/api7ee/provider_test.go
+++ b/internal/provider/api7ee/provider_test.go
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api7ee
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	adcclient "github.com/apache/apisix-ingress-controller/internal/adc/client"
+	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
+)
+
+type readyManager struct{}
+
+func (readyManager) RegisterGVK(...readiness.GVKConfig) {}
+func (readyManager) Start(context.Context) error        { return nil }
+func (readyManager) IsReady() bool                      { return true }
+func (readyManager) WaitReady(context.Context, time.Duration) bool {
+	return true
+}
+func (readyManager) Done(client.Object, k8stypes.NamespacedName) {}
+
+func TestStartConsumesNotificationsWhenPeriodicSyncDisabled(t *testing.T) {
+	adc, err := adcclient.New(logr.Discard(), ProviderTypeAPI7EE, time.Second)
+	require.NoError(t, err)
+
+	provider := &api7eeProvider{
+		client:  adc,
+		readier: readyManager{},
+		syncCh:  make(chan struct{}, 1),
+		log:     logr.Discard(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- provider.Start(ctx)
+	}()
+
+	require.Eventually(t, provider.startUpSync.Load, time.Second, 10*time.Millisecond)
+	provider.syncNotify()
+	require.Eventually(t, func() bool {
+		return len(provider.syncCh) == 0
+	}, time.Second, 10*time.Millisecond)
+
+	select {
+	case err := <-done:
+		require.Failf(t, "provider stopped", "Start returned before cancellation: %v", err)
+	default:
+	}
+
+	cancel()
+	assert.NoError(t, <-done)
+}

--- a/internal/provider/api7ee/provider_test.go
+++ b/internal/provider/api7ee/provider_test.go
@@ -30,7 +30,6 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	adcclient "github.com/apache/apisix-ingress-controller/internal/adc/client"
 	"github.com/apache/apisix-ingress-controller/internal/manager/readiness"
 )
 
@@ -45,14 +44,15 @@ func (readyManager) WaitReady(context.Context, time.Duration) bool {
 func (readyManager) Done(client.Object, k8stypes.NamespacedName) {}
 
 func TestStartConsumesNotificationsWhenPeriodicSyncDisabled(t *testing.T) {
-	adc, err := adcclient.New(logr.Discard(), ProviderTypeAPI7EE, time.Second)
-	require.NoError(t, err)
-
+	var syncCalls atomic.Int32
 	provider := &api7eeProvider{
-		client:  adc,
 		readier: readyManager{},
 		syncCh:  make(chan struct{}, 1),
-		log:     logr.Discard(),
+		syncFn: func(context.Context) error {
+			syncCalls.Add(1)
+			return nil
+		},
+		log: logr.Discard(),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -61,10 +61,12 @@ func TestStartConsumesNotificationsWhenPeriodicSyncDisabled(t *testing.T) {
 		done <- provider.Start(ctx)
 	}()
 
-	require.Eventually(t, provider.startUpSync.Load, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return syncCalls.Load() >= 1
+	}, time.Second, 10*time.Millisecond)
 	provider.syncNotify()
 	require.Eventually(t, func() bool {
-		return len(provider.syncCh) == 0
+		return syncCalls.Load() >= 2
 	}, time.Second, 10*time.Millisecond)
 
 	select {

--- a/internal/provider/api7ee/provider_test.go
+++ b/internal/provider/api7ee/provider_test.go
@@ -19,6 +19,8 @@ package api7ee
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -70,6 +72,34 @@ func TestStartConsumesNotificationsWhenPeriodicSyncDisabled(t *testing.T) {
 		require.Failf(t, "provider stopped", "Start returned before cancellation: %v", err)
 	default:
 	}
+
+	cancel()
+	assert.NoError(t, <-done)
+}
+
+func TestStartRetriesStartupFailureWhenPeriodicSyncDisabled(t *testing.T) {
+	var syncCalls atomic.Int32
+	provider := &api7eeProvider{
+		readier: readyManager{},
+		syncCh:  make(chan struct{}, 1),
+		syncFn: func(context.Context) error {
+			if syncCalls.Add(1) == 1 {
+				return errors.New("startup sync failed")
+			}
+			return nil
+		},
+		log: logr.Discard(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- provider.Start(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return syncCalls.Load() >= 2
+	}, 2*time.Second, 10*time.Millisecond)
 
 	cancel()
 	assert.NoError(t, <-done)


### PR DESCRIPTION
## Summary

- keep event-driven synchronization and retries active when `sync_period: 0s` disables only periodic synchronization
- add regression coverage for notification consumption with periodic synchronization disabled
- align the sample configuration with API7 Ingress Controller binary defaults
- correct leader-election, debug-server, and listener-port documentation
- correct stale APISIX product wording in the API7 configuration pages

## Why

The API7 binary defaults to `sync_period: 0s`, but the provider previously returned from `Start` when the value was zero. That stopped the loop consuming configuration-change notifications and retries, so later `GatewayProxy` changes could remain unapplied.

The sample and reference also mixed binary and Helm defaults and omitted an important listener-port matching constraint.

## Validation

- `go test -v ./internal/provider/api7ee ./internal/controller/config`
- `go test ./internal/provider/...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated product terminology throughout configuration guides to API7 Ingress.
  - Clarified ConfigMap and Helm-generated configuration behavior.
  - Documented listener port matching options and clarified synchronization timing.
  - Updated leader-election examples and debug server defaults.

- **Reliability**
  - Improved synchronization startup and retry behavior after failures.
  - Periodic synchronization can be disabled while event-driven updates continue to be processed.
  - Successful synchronization now resets retry handling, and shutdown remains responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->