### PR TITLE
fix: stop the status e2e tests demanding their old node ports back

### DIFF
--- a/test/e2e/crds/v2/status.go
+++ b/test/e2e/crds/v2/status.go
@@ -211,6 +211,12 @@ spec:
 			Expect(err).NotTo(HaveOccurred(), "getting service yaml")
 			err = yaml.Unmarshal([]byte(serviceYaml), &k8sservice)
 			Expect(err).NotTo(HaveOccurred(), "unmarshalling service")
+			// Switching to ExternalName released the allocated node ports, and a service
+			// in a parallel test namespace may have taken them since. Ask for fresh ones
+			// instead of the old numbers, which would fail with "already allocated".
+			for i := range oldSpec.Ports {
+				oldSpec.Ports[i].NodePort = 0
+			}
 			k8sservice.Spec = oldSpec
 			newServiceYaml, err = yaml.Marshal(k8sservice)
 			Expect(err).NotTo(HaveOccurred(), "marshalling service")

--- a/test/e2e/gatewayapi/status.go
+++ b/test/e2e/gatewayapi/status.go
@@ -157,6 +157,12 @@ spec:
 			Expect(err).NotTo(HaveOccurred(), "getting service yaml")
 			err = yaml.Unmarshal([]byte(serviceYaml), &k8sservice)
 			Expect(err).NotTo(HaveOccurred(), "unmarshalling service")
+			// Switching to ExternalName released the allocated node ports, and a service
+			// in a parallel test namespace may have taken them since. Ask for fresh ones
+			// instead of the old numbers, which would fail with "already allocated".
+			for i := range oldSpec.Ports {
+				oldSpec.Ports[i].NodePort = 0
+			}
 			k8sservice.Spec = oldSpec
 			newServiceYaml, err = yaml.Marshal(k8sservice)
 			Expect(err).NotTo(HaveOccurred(), "marshalling service")


### PR DESCRIPTION
### Type of change:

- [x] CI/CD or Tests

### What this PR does / why we need it:

The `dataplane unavailable` spec is flaky, and it fails like this:

```
[FAIL] Test Gateway API Status Test HTTPRoute Sync Status [It] dataplane unavailable
test/e2e/gatewayapi/status.go:161

[FAILED] creating service
Unexpected error:
  The Service "apisix-standalone" is invalid: spec.ports[6].nodePort:
  Invalid value: 32746: provided port is already allocated
```

The spec captures the dataplane Service's spec, flips the Service to `ExternalName` so the route sync fails, checks the `SyncFailed` status, then restores the captured spec. Switching to `ExternalName` releases the node ports the Service held, but the captured spec still names them — so the restore demands those exact port numbers back. The e2e suite runs many namespaces in parallel, so by then another Service may have been allocated one of them, and the restore is rejected.

That race is why it passes most of the time rather than never. The fix is to clear `NodePort` before restoring and let the API server allocate whatever is free; these tests reach the dataplane through a port-forward tunnel, so the actual port numbers are never depended on.

`test/e2e/crds/v2/status.go` has the same capture-and-restore, so it gets the same fix.

No new test cases: this is a fix to existing tests, and the failure is a scheduling race that isn't worth reproducing deterministically.

### Pre-submission checklist:

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible?

Ports apache/apisix-ingress-controller#2845, which carries the same change upstream.
